### PR TITLE
performance optimisation when stage has been disposed of

### DIFF
--- a/src/stage/mouse-observer.ts
+++ b/src/stage/mouse-observer.ts
@@ -142,6 +142,7 @@ class MouseObserver {
   lastClicked: number
   overElement: boolean
   lastTouchDistance: number
+  private frameRequest: number
 
   /**
    * @param  {Element} domElement - the dom element to observe mouse events in
@@ -218,7 +219,7 @@ class MouseObserver {
         this.signals.hovered.dispatch(cp.x, cp.y)
       }
     }
-    window.requestAnimationFrame(this._listen)
+    this.frameRequest = window.requestAnimationFrame(this._listen)
   }
 
   /**
@@ -473,6 +474,7 @@ class MouseObserver {
     document.removeEventListener('touchstart', this._onTouchstart)
     document.removeEventListener('touchend', this._onTouchend)
     document.removeEventListener('touchmove', this._onTouchmove)
+    window.cancelAnimationFrame(this.frameRequest)
   }
 }
 

--- a/src/stage/stage.ts
+++ b/src/stage/stage.ts
@@ -920,6 +920,7 @@ class Stage {
   dispose () {
     this.tasks.dispose()
     this.viewer.dispose()
+    this.mouseObserver.dispose()
   }
 }
 

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -182,6 +182,7 @@ export default class Viewer {
   private renderPending: boolean
   private lastRenderedPicking: boolean
   private isStill: boolean
+  private frameRequest: number
 
   sampleLevel: number
   private cDist: number
@@ -936,7 +937,7 @@ export default class Viewer {
       if (Debug) Log.log('rendered still frame')
     }
 
-    window.requestAnimationFrame(this.animate)
+    this.frameRequest = window.requestAnimationFrame(this.animate)
   }
 
   pick (x: number, y: number) {
@@ -1312,5 +1313,6 @@ export default class Viewer {
 
   dispose () {
     this.renderer.dispose()
+    window.cancelAnimationFrame(this.frameRequest)
   }
 }


### PR DESCRIPTION
I realised that there were some functions still being called recursively at every frame even after removing the scene.
In hope of getting rid of as much as I could, I was removing everything by doing:
```js
stage.removeAllComponents();
stage.dispose();
stage.viewer.container.innerHTML = "";
stage = null;
```
This might not be too much of a problem in some pages, but if you happen to add and remove stages a lot (popup/modal with ngl viewer, or single-page applications) then this can build up.

![Screenshot from 2019-10-06 22-40-25](https://user-images.githubusercontent.com/6025561/66275960-4c9f0200-e88e-11e9-81f4-a48c03a90f7d.png)
After adding and removing a stage 20 times (using a modified version of `/examples/embedded.html`) This is what I would get on the performance tab of Chrome.
Every single frame I would have 20 calls to `mouseObserver._listen()` and 20 to `viewer.animate()` that would amount to about 5ms of useless use of the main thread, and memory usage growing (even if it does get caught by the garbage collector eventually).

Compare to this screenshot using the code in this PR
![Screenshot from 2019-10-06 22-42-14](https://user-images.githubusercontent.com/6025561/66276050-29c11d80-e88f-11e9-8f21-19d67c3a95fe.png)
Here with have absolutely nothing happening after doing the same steps, which is way better regarding resource usage.


