### PR TITLE
Fix picking, measurements and contact labels when using component.setTransform

### DIFF
--- a/examples/scripts/test/matrix.js
+++ b/examples/scripts/test/matrix.js
@@ -1,8 +1,8 @@
-stage.loadFile('data://1blu.pdb').then(function (o) {
+const a = [-0.017893094929114478, 0.44789033770201286, 0.8939094375533996, 0, 0.9995957623640608, -0.011742974659610292, 0.025892362000326047, 0, 0.022094094633404514, 0.8940113802068294, -0.4474991654104058, 0, 14.428066535570798, 7.843669892047377, 7.242749062873044, 1]
+
+stage.loadFile('data://1lee.pdb').then(function (o) {
   // Check correct behaviour of picking/representation etc when
   // applying a transformation matrix to a component.
-  const a = [-0.017893094929114478, 0.44789033770201286, 0.8939094375533996, 0, 0.9995957623640608, -0.011742974659610292, 0.025892362000326047, 0, 0.022094094633404514, 0.8940113802068294, -0.4474991654104058, 0, 14.428066535570798, 7.843669892047377, 7.242749062873044, 1]
-
   const m = new NGL.Matrix4()
   m.fromArray(a)
 
@@ -37,4 +37,17 @@ stage.loadFile('data://1blu.pdb').then(function (o) {
 
   console.log(a)
   console.log(m)
+})
+
+stage.loadFile('data://1lee.ccp4').then(function (o) {
+  const m = new NGL.Matrix4()
+  m.fromArray(a)
+
+  o.setTransform(m)
+  o.addRepresentation('surface', {
+    contour: true,
+    color: 'skyblue',
+    boxSize: 10,
+    useWorker: false
+  })
 })

--- a/examples/scripts/test/matrix.js
+++ b/examples/scripts/test/matrix.js
@@ -1,0 +1,40 @@
+stage.loadFile('data://1blu.pdb').then(function (o) {
+  // Check correct behaviour of picking/representation etc when
+  // applying a transformation matrix to a component.
+  const a = [-0.017893094929114478, 0.44789033770201286, 0.8939094375533996, 0, 0.9995957623640608, -0.011742974659610292, 0.025892362000326047, 0, 0.022094094633404514, 0.8940113802068294, -0.4474991654104058, 0, 14.428066535570798, 7.843669892047377, 7.242749062873044, 1]
+
+  const m = new NGL.Matrix4()
+  m.fromArray(a)
+
+  o.setTransform(m)
+
+  o.addRepresentation('cartoon', { sele: '*' })
+  o.addRepresentation('backbone', {
+    sele: '*',
+    scale: 1.0,
+    aspectRatio: 1.5,
+    color: 'lightgreen'
+  })
+  o.addRepresentation('licorice', { sele: '*', scale: 1.0 })
+
+  // TextBuffer was not correctly transformed as of commit d6a567a
+  o.addRepresentation('contact', {labelVisible: true})
+
+  var atomPair = [
+    [ '1.CA', '10.CA' ],
+    [ 1, 209 ]
+  ]
+
+  o.addRepresentation('distance', {
+    atomPair: atomPair,
+    color: 'skyblue',
+    labelUnit: 'nm'
+  })
+
+  var center = o.getCenter('101')
+  var zoom = o.getZoom('101')
+  stage.animationControls.zoomMove(center, zoom, 0)
+
+  console.log(a)
+  console.log(m)
+})

--- a/src/component/component.ts
+++ b/src/component/component.ts
@@ -189,12 +189,20 @@ abstract class Component {
 
     this.matrix.premultiply(this.transform)
 
-    this.reprList.forEach(repr => {
-      repr.setParameters({ matrix: this.matrix })
-    })
+    this.updateRepresentationMatrices()
+
     this.stage.viewer.updateBoundingBox()
 
     this.signals.matrixChanged.dispatch(this.matrix)
+  }
+
+  /**
+   * Propogates our matrix to each representation
+   */
+  updateRepresentationMatrices () {
+    this.reprList.forEach(repr => {
+      repr.setParameters({ matrix: this.matrix })
+    })
   }
 
   /**

--- a/src/component/structure-component.ts
+++ b/src/component/structure-component.ts
@@ -260,6 +260,15 @@ class StructureComponent extends Component {
     this.measureRepresentations.update(what)
   }
 
+  /**
+   * Overrides {@link Component.updateRepresentationMatrices} 
+   * to also update matrix for measureRepresentations 
+   */
+  updateRepresentationMatrices () {
+    super.updateRepresentationMatrices()
+    this.measureRepresentations.setParameters({ matrix: this.matrix })
+  }
+
   addRepresentation <K extends keyof StructureRepresentationParametersMap>(
     type: K,
     params: Partial<StructureRepresentationParametersMap[K]>|{defaultAssembly: string} = {},

--- a/src/controls/picking-proxy.ts
+++ b/src/controls/picking-proxy.ts
@@ -153,15 +153,21 @@ class PickingProxy {
    * The atom of a picked bond that is closest to the mouse
    * @type {AtomProxy}
    */
-  get closestBondAtom () {
+  get closestBondAtom (): AtomProxy|undefined {
     if (this.type !== 'bond' || !this.bond) return undefined
 
     const bond = this.bond
     const controls = this.controls
     const cp = this.canvasPosition
 
-    const acp1 = controls.getPositionOnCanvas(bond.atom1 as any)  // TODO
-    const acp2 = controls.getPositionOnCanvas(bond.atom2 as any)  // TODO
+    const v1 = bond.atom1.positionToVector3()
+    const v2 = bond.atom2.positionToVector3()
+
+    v1.applyMatrix4(this.component.matrix)
+    v2.applyMatrix4(this.component.matrix)
+
+    const acp1 = controls.getPositionOnCanvas(v1)
+    const acp2 = controls.getPositionOnCanvas(v2)
 
     return closer(cp as any, acp1, acp2) ? bond.atom1 : bond.atom2
   }
@@ -170,12 +176,14 @@ class PickingProxy {
    * Close-by atom
    * @type {AtomProxy}
    */
-  get closeAtom () {
+  get closeAtom (): AtomProxy|undefined {
     const cp = this.canvasPosition
-    const ca = this.closestBondAtom!
+    const ca = this.closestBondAtom
     if (!ca) return undefined
 
-    const acp = this.controls.getPositionOnCanvas(ca as any)  // TODO
+    const v = ca.positionToVector3().applyMatrix4(this.component.matrix)
+
+    const acp = this.controls.getPositionOnCanvas(v)
 
     ca.positionToVector3(tmpVec)
     if (this.instance) tmpVec.applyMatrix4(this.instance.matrix)

--- a/src/proxy/atom-proxy.ts
+++ b/src/proxy/atom-proxy.ts
@@ -663,7 +663,7 @@ class AtomProxy {
    * @param  {Vector3} [v] - target vector
    * @return {Vector3} target vector
    */
-  positionToVector3 (v: Vector3) {
+  positionToVector3 (v?: Vector3) {
     if (v === undefined) v = new Vector3()
 
     v.x = this.x

--- a/src/representation/contact-representation.ts
+++ b/src/representation/contact-representation.ts
@@ -323,7 +323,7 @@ class ContactRepresentation extends StructureRepresentation {
       }
       bufferList.push(new TextBuffer(
         getLabelData(contactData, labelParams),
-        {fixedSize: this.labelFixedSize}
+        this.getBufferParams({fixedSize: this.labelFixedSize})
       ))
     }
 

--- a/src/representation/representation.ts
+++ b/src/representation/representation.ts
@@ -130,7 +130,7 @@ class Representation {
   protected disableImpostor: boolean
   protected disposed: boolean
 
-  private matrix: Matrix4
+  protected matrix: Matrix4
 
   private quality: string
   visible: boolean

--- a/src/representation/surface-representation.ts
+++ b/src/representation/surface-representation.ts
@@ -4,7 +4,7 @@
  * @private
  */
 
-import { Vector3, Box3 } from 'three'
+import { Matrix4, Vector3, Box3 } from 'three'
 
 import { defaults } from '../utils'
 import Representation, { RepresentationParameters } from './representation.js'
@@ -70,6 +70,7 @@ class SurfaceRepresentation extends Representation {
   protected background: boolean
   protected opaqueBack: boolean
   protected boxSize: number
+  protected inverseMatrix: Matrix4
   protected colorVolume: Volume
   protected contour: boolean
   protected useWorker: boolean
@@ -146,8 +147,11 @@ class SurfaceRepresentation extends Representation {
     this.__box = new Box3()
 
     this._position = new Vector3()
+    this.inverseMatrix = new Matrix4()
+
     this.setBox = function setBox () {
       this._position.copy(viewer.translationGroup.position).negate()
+      this._position.applyMatrix4(this.inverseMatrix)
       if (!this._position.equals(this.boxCenter)) {
         this.setParameters({ 'boxCenter': this._position })
       }
@@ -179,6 +183,8 @@ class SurfaceRepresentation extends Representation {
     this.wrap = defaults(p.wrap, false)
 
     super.init(p)
+
+    this.inverseMatrix.getInverse(this.matrix)
 
     this.build()
   }
@@ -356,6 +362,10 @@ class SurfaceRepresentation extends Representation {
     }
 
     super.setParameters(params, what, rebuild)
+
+    if (params.matrix) {
+      this.inverseMatrix.getInverse(params.matrix)
+    }
 
     if (this.volume) {
       this.volume.getBox(this.boxCenter, this.boxSize, this.box)


### PR DESCRIPTION
This fixes a few bugs when a matrix is used to transform a component (component.setTransform(m: Matrix4)).

Specifically:

In picking-proxy, when trying to detect which atom is closer to the picked point (converting 3D coords to 2D screen position), the component matrix is not applied.

StructureComponent has a few special representations (for picking/measurements), these are now transformed as well

When using labels in ContactRepresentation, the generated TextBuffer was not being passed a full set of parameters.