### PR TITLE
Avoid extra rebuilds on param changes when nothing is picked

### DIFF
--- a/src/component/structure-component.ts
+++ b/src/component/structure-component.ts
@@ -436,7 +436,8 @@ class StructureComponent extends Component {
     this.spacefillRepresentation.setSelection(
       pickData.length ? ( '@' + pickData.join(',') ) : 'none'
     )
-    this.spacefillRepresentation.setParameters({ radiusData })
+    if (pickData.length)
+      this.spacefillRepresentation.setParameters({ radiusData })
   }
 
   measureData () {


### PR DESCRIPTION
Before this, `measureUpdate` would always pass `radiusData` to `setParameters`,
which would rebuild because it only checks for undefined.
This commit avoids calling `spacefillRepresentation.setParameters` if there's nothing to do, which
should speed up frame rate in some cases.