### PR TITLE
Fix negative zoom in orthographic camera

### DIFF
--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -1053,7 +1053,7 @@ export default class Viewer {
 
   updateZoom () {
     const fov = degToRad(this.perspectiveCamera.fov)
-    const height = 2 * Math.tan(fov / 2) * -this.cameraDistance // fix for camera rig
+    const height = 2 * Math.tan(fov / 2) * this.cameraDistance
     this.orthographicCamera.zoom = this.height / height
   }
 


### PR DESCRIPTION
Almost a one-character change (Fixes #779)

@garyo, I don't think this would have any consequences for your camera changes (unless you read orthographic.camera.zoom?)

