### PR TITLE
Fix regexp for SDF extra data

### DIFF
--- a/src/parser/sdf-parser.ts
+++ b/src/parser/sdf-parser.ts
@@ -8,7 +8,7 @@ import { Debug, Log, ParserRegistry } from '../globals'
 import { assignResidueTypeBonds } from '../structure/structure-utils'
 import StructureParser from './structure-parser'
 
-const reItem = /> <(.+)>/
+const reItem = /> +<(.+)>/
 
 class SdfParser extends StructureParser {
   get type () { return 'sdf' }


### PR DESCRIPTION
This PR fixes the regexp used for parsing extra data in SDF files.

According to [SDF spec showed in Wikipedia](https://en.wikipedia.org/wiki/Chemical_table_file#SDF),  extra data items in SDF files are denoted as follows.
The number of spaces between `>` and `<` is 2.

```
>  <Unique_ID>
XCA3464366
 
>  <ClogP>
5.825

>  <Vendor>
Sigma

>  <Molecular Weight>
499.611
```

However, [the current regexp that is used to search for metadata (`/> <(.+)>/`)](https://github.com/nglviewer/ngl/blob/v2.0.0-dev.37/src/parser/sdf-parser.ts#L11) contains only 1 space between `>` and `<`.

Therefore, I fixed the regexp to match the above example too.