### PR TITLE
Avoid divide-by-zero when normalizing vectors

### DIFF
--- a/src/math/vector-utils.ts
+++ b/src/math/vector-utils.ts
@@ -146,10 +146,14 @@ export function normalizeVector3array (a: Float32Array) {
     const x = a[ i ]
     const y = a[ i + 1 ]
     const z = a[ i + 2 ]
-    const s = 1 / Math.sqrt(x * x + y * y + z * z)
-    a[ i ] = x * s
-    a[ i + 1 ] = y * s
-    a[ i + 2 ] = z * s
+    const len2 = x * x + y * y + z * z
+    if (len2 > 0) {             // avoid divide by zero
+      const s = 1 / Math.sqrt(len2)
+      a[ i ] = x * s
+      a[ i + 1 ] = y * s
+      a[ i + 2 ] = z * s
+    }
+    // else leave as all zeros
   }
 }
 


### PR DESCRIPTION
There's no "right" answer for what to do when normalizing a (0,0,0)
vector, but NaNs is definitely not a good result. This just leaves
the vector as (0,0,0), non-normalized but numerically valid.

Zero-length vectors can result from creating normals when building
isosurfaces, when a triangle is zero area.

I ran across this with a SARS-Cov2 model, making a vws surface. I think
it creates a zero-area triangle which triggers these NaNs in the triangle 
normals and positions. You don't notice them normally when just
viewing the results (three.js seems to be fairly forgiving, but I export
glTFs and they are fatal there.