### PR TITLE
Color management: linear workflow

### DIFF
--- a/src/color/atomindex-colormaker.ts
+++ b/src/color/atomindex-colormaker.ts
@@ -6,7 +6,7 @@
 
 import { ColormakerRegistry } from '../globals'
 import { defaults } from '../utils'
-import Colormaker, { StuctureColormakerParams, ColormakerScale } from './colormaker'
+import Colormaker, { StuctureColormakerParams, ColormakerScale, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 import ModelProxy from '../proxy/model-proxy'
 
@@ -47,6 +47,7 @@ class AtomindexColormaker extends Colormaker {
    * @param  {AtomProxy} atom - atom to get color for
    * @return {Integer} hex atom color
    */
+  @manageColor
   atomColor (atom: AtomProxy) {
     return this.scalePerModel[ atom.modelIndex ](atom.index)
   }

--- a/src/color/bfactor-colormaker.ts
+++ b/src/color/bfactor-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { StuctureColormakerParams, ColormakerScale } from './colormaker'
+import Colormaker, { StuctureColormakerParams, ColormakerScale, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 import Selection from '../selection/selection'
 
@@ -52,6 +52,7 @@ class BfactorColormaker extends Colormaker {
     this.bfactorScale = this.getScale()
   }
 
+  @manageColor
   atomColor (a: AtomProxy) {
     return this.bfactorScale(a.bfactor)
   }

--- a/src/color/chainid-colormaker.ts
+++ b/src/color/chainid-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { StuctureColormakerParams, ColormakerScale } from './colormaker'
+import Colormaker, { StuctureColormakerParams, ColormakerScale, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 import ChainProxy from '../proxy/chain-proxy'
 import ModelProxy from '../proxy/model-proxy'
@@ -41,6 +41,7 @@ class ChainidColormaker extends Colormaker {
     })
   }
 
+  @manageColor
   atomColor (a: AtomProxy) {
     const chainidDict = this.chainidDictPerModel[ a.modelIndex ]
     return this.scalePerModel[ a.modelIndex ](chainidDict[ a.chainid ])

--- a/src/color/chainindex-colormaker.ts
+++ b/src/color/chainindex-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { StuctureColormakerParams, ColormakerScale } from './colormaker'
+import Colormaker, { StuctureColormakerParams, ColormakerScale, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 import ModelProxy from '../proxy/model-proxy'
 
@@ -28,6 +28,7 @@ class ChainindexColormaker extends Colormaker {
     })
   }
 
+  @manageColor
   atomColor (a: AtomProxy) {
     return this.scalePerModel[ a.modelIndex ](a.chainIndex)
   }

--- a/src/color/chainname-colormaker.ts
+++ b/src/color/chainname-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { StuctureColormakerParams, ColormakerScale } from './colormaker'
+import Colormaker, { StuctureColormakerParams, ColormakerScale, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 import ChainProxy from '../proxy/chain-proxy'
 import ModelProxy from '../proxy/model-proxy'
@@ -41,6 +41,7 @@ class ChainnameColormaker extends Colormaker {
     })
   }
 
+  @manageColor
   atomColor (a: AtomProxy) {
     const chainnameDict = this.chainnameDictPerModel[ a.modelIndex ]
     return this.scalePerModel[ a.modelIndex ](chainnameDict[ a.chainname ])

--- a/src/color/colormaker.ts
+++ b/src/color/colormaker.ts
@@ -25,7 +25,7 @@ export const ScaleDefaultParameters = {
   domain: [ 0, 1 ] as number[],
   value: 0xFFFFFF,
   reverse: false,
-  colorSpace: 'linear' as ColorSpace // XXX sRGB should be default for compatibility
+  colorSpace: 'linear' as ColorSpace // TODO: hook up to Viewer colorEncoding
 }
 export type ScaleParameters = typeof ScaleDefaultParameters
 

--- a/src/color/colormaker.ts
+++ b/src/color/colormaker.ts
@@ -25,7 +25,7 @@ export type ColorSpace = 'sRGB' | 'linear'
  * as vertex or texture colors.
  * @see setColorSpace/getColorSpace.
  */
-var colorSpace = 'linear' as ColorSpace
+var colorSpace: ColorSpace = 'sRGB' // default: don't linearize
 
 /** Set the global internal color space for colormakers */
 export function setColorSpace(space: ColorSpace) {

--- a/src/color/colormaker.ts
+++ b/src/color/colormaker.ts
@@ -16,8 +16,26 @@ import AtomProxy from '../proxy/atom-proxy'
 import BondProxy from '../proxy/bond-proxy'
 
 export type ColorMode = 'rgb'|'hsv'|'hsl'|'hsi'|'lab'|'hcl'
-
 export type ColorSpace = 'sRGB' | 'linear'
+
+/**
+ * Internal color space for all colors (global).
+ * Colors are always specified as sRGB; if this is set to
+ * 'linear' then colors get linearized when used internally
+ * as vertex or texture colors.
+ * @see setColorSpace/getColorSpace.
+ */
+var colorSpace = 'linear' as ColorSpace
+
+/** Set the global internal color space for colormakers */
+export function setColorSpace(space: ColorSpace) {
+  colorSpace = space
+}
+
+/** Get the global internal color space for colormakers */
+export function getColorSpace() {
+  return colorSpace
+}
 
 export const ScaleDefaultParameters = {
   scale: 'uniform' as string|string[],
@@ -25,7 +43,6 @@ export const ScaleDefaultParameters = {
   domain: [ 0, 1 ] as number[],
   value: 0xFFFFFF,
   reverse: false,
-  colorSpace: 'linear' as ColorSpace // TODO: hook up to Viewer colorEncoding
 }
 export type ScaleParameters = typeof ScaleDefaultParameters
 
@@ -50,7 +67,7 @@ export function manageColor<T extends {parameters: ColormakerParameters}>
     const originalMethod = descriptor.value
     const linearize: colorFuncType = function (this: T, value: any) {
       let result = originalMethod!.bind(this, value)()
-      if (this.parameters.colorSpace == 'linear') {
+      if (colorSpace == 'linear') {
         tmpColor.set(result)
         tmpColor.convertSRGBToLinear()
         return tmpColor.getHex()

--- a/src/color/densityfit-colormaker.ts
+++ b/src/color/densityfit-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { StuctureColormakerParams, ColormakerScale } from './colormaker'
+import Colormaker, { StuctureColormakerParams, ColormakerScale, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 
 /**
@@ -36,6 +36,7 @@ class DensityfitColormaker extends Colormaker {
 
   }
 
+  @manageColor
   atomColor (atom: AtomProxy) {
     let sele = atom.resno + ''
     if (atom.inscode) sele += '^' + atom.inscode

--- a/src/color/electrostatic-colormaker.ts
+++ b/src/color/electrostatic-colormaker.ts
@@ -8,7 +8,7 @@
 import { Vector3 } from 'three'
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { StuctureColormakerParams, ColormakerScale } from './colormaker'
+import Colormaker, { StuctureColormakerParams, ColormakerScale, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 import SpatialHash from '../geometry/spatial-hash'
 
@@ -270,6 +270,7 @@ class ElectrostaticColormaker extends Colormaker {
     this.hash = new SpatialHash(params.structure.atomStore, bbox)
   }
 
+  @manageColor
   positionColor (v: Vector3) {
 
     const charges = this.charges

--- a/src/color/element-colormaker.ts
+++ b/src/color/element-colormaker.ts
@@ -6,7 +6,7 @@
 
 import { ColormakerRegistry } from '../globals'
 import { defaults } from '../utils'
-import Colormaker, { ColormakerParameters } from './colormaker'
+import Colormaker, { ColormakerParameters, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 
 // from Jmol http://jmol.sourceforge.net/jscolors/ (or 0xFFFFFF)
@@ -144,6 +144,8 @@ class ElementColormaker extends Colormaker {
     super(params)
   }
 
+
+  @manageColor
   atomColor (a: AtomProxy) {
     const element = a.element
 

--- a/src/color/entityindex-colormaker.ts
+++ b/src/color/entityindex-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { StuctureColormakerParams, ColormakerScale } from './colormaker'
+import Colormaker, { StuctureColormakerParams, ColormakerScale, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 
 /**
@@ -27,6 +27,7 @@ class EntityindexColormaker extends Colormaker {
     this.entityindexScale = this.getScale()
   }
 
+  @manageColor
   atomColor (a: AtomProxy) {
     return this.entityindexScale(a.entityIndex)
   }

--- a/src/color/entitytype-colormaker.ts
+++ b/src/color/entitytype-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker from './colormaker'
+import Colormaker, { manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 
 import {
@@ -16,6 +16,7 @@ import {
  * Color by entity type
  */
 class EntitytypeColormaker extends Colormaker {
+  @manageColor
   atomColor (a: AtomProxy) {
     const e = a.entity
     const et = e ? e.entityType : undefined

--- a/src/color/geoquality-colormaker.ts
+++ b/src/color/geoquality-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { StuctureColormakerParams } from './colormaker'
+import Colormaker, { StuctureColormakerParams, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 import { countSetBits } from '../math/math-utils'
 
@@ -26,6 +26,7 @@ class GeoqualityColormaker extends Colormaker {
     }
   }
 
+  @manageColor
   atomColor (atom: AtomProxy) {
     let sele = atom.resno + ''
     if (atom.inscode) sele += '^' + atom.inscode

--- a/src/color/hydrophobicity-colormaker.ts
+++ b/src/color/hydrophobicity-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { ColormakerParameters, ColormakerScale } from './colormaker'
+import Colormaker, { ColormakerParameters, ColormakerScale, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 
 import {
@@ -50,6 +50,7 @@ class HydrophobicityColormaker extends Colormaker {
     this.hfScale = this.getScale()
   }
 
+  @manageColor
   atomColor (a: AtomProxy) {
     return this.hfScale(this.resHF[ a.resname ] || this.defaultResidueHydrophobicity)
   }

--- a/src/color/modelindex-colormaker.ts
+++ b/src/color/modelindex-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { StuctureColormakerParams, ColormakerScale } from './colormaker'
+import Colormaker, { StuctureColormakerParams, ColormakerScale, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 
 /**
@@ -27,6 +27,7 @@ class ModelindexColormaker extends Colormaker {
     this.modelindexScale = this.getScale()
   }
 
+  @manageColor
   atomColor (a: AtomProxy) {
     return this.modelindexScale(a.modelIndex)
   }

--- a/src/color/moleculetype-colormaker.ts
+++ b/src/color/moleculetype-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker from './colormaker'
+import Colormaker, { manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 
 import {
@@ -16,6 +16,7 @@ import {
  * Color by molecule type
  */
 class MoleculetypeColormaker extends Colormaker {
+  @manageColor
   atomColor (a: AtomProxy) {
     switch (a.residueType.moleculeType) {
       case WaterType:

--- a/src/color/occupancy-colormaker.ts
+++ b/src/color/occupancy-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { ColormakerParameters, ColormakerScale } from './colormaker'
+import Colormaker, { ColormakerParameters, ColormakerScale, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 
 /**
@@ -28,6 +28,7 @@ class OccupancyColormaker extends Colormaker {
     this.occupancyScale = this.getScale()
   }
 
+  @manageColor
   atomColor (a: AtomProxy) {
     return this.occupancyScale(a.occupancy)
   }

--- a/src/color/partialcharge-colormaker.ts
+++ b/src/color/partialcharge-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { ColormakerParameters, ColormakerScale } from './colormaker'
+import Colormaker, { ColormakerParameters, ColormakerScale, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 
 /**
@@ -37,6 +37,7 @@ class PartialchargeColormaker extends Colormaker {
     this.partialchargeScale = this.getScale()
   }
 
+  @manageColor
   atomColor (a: AtomProxy) {
     return this.partialchargeScale(a.partialCharge || 0)
   }

--- a/src/color/random-colormaker.ts
+++ b/src/color/random-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker from './colormaker'
+import Colormaker, { manageColor } from './colormaker'
 
 function randomColor () {
   return Math.random() * 0xFFFFFF
@@ -19,6 +19,7 @@ class RandomColormaker extends Colormaker {
    * get color for an atom
    * @return {Integer} random hex color
    */
+  @manageColor
   atomColor () {
     return randomColor()
   }
@@ -27,6 +28,7 @@ class RandomColormaker extends Colormaker {
    * get color for volume cell
    * @return {Integer} random hex color
    */
+  @manageColor
   volumeColor () {
     return randomColor()
   }
@@ -35,6 +37,7 @@ class RandomColormaker extends Colormaker {
    * get color for coordinates in space
    * @return {Integer} random hex color
    */
+  @manageColor
   positionColor () {
     return randomColor()
   }

--- a/src/color/randomcoilindex-colormaker.ts
+++ b/src/color/randomcoilindex-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { StuctureColormakerParams, ColormakerScale } from './colormaker'
+import Colormaker, { StuctureColormakerParams, ColormakerScale, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 
 /**
@@ -29,6 +29,7 @@ class RandomcoilindexColormaker extends Colormaker {
 
   }
 
+  @manageColor
   atomColor (atom: AtomProxy) {
     let sele = `[${atom.resname}]${atom.resno}`
     if (atom.chainname) sele += ':' + atom.chainname

--- a/src/color/residueindex-colormaker.ts
+++ b/src/color/residueindex-colormaker.ts
@@ -6,7 +6,7 @@
 
 import { ColormakerRegistry } from '../globals'
 import { defaults } from '../utils'
-import Colormaker, { StuctureColormakerParams, ColormakerScale } from './colormaker'
+import Colormaker, { StuctureColormakerParams, ColormakerScale, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 import ChainProxy from '../proxy/chain-proxy'
 
@@ -30,6 +30,7 @@ class ResidueindexColormaker extends Colormaker {
     })
   }
 
+  @manageColor
   atomColor (a: AtomProxy) {
     return this.scalePerChain[ a.chainIndex ](a.residueIndex)
   }

--- a/src/color/resname-colormaker.ts
+++ b/src/color/resname-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker from './colormaker'
+import Colormaker, { manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 
 // protein colors from Jmol http://jmol.sourceforge.net/jscolors/
@@ -60,6 +60,7 @@ const DefaultResidueColor = 0xFF00FF
  * Color by residue name
  */
 class ResnameColormaker extends Colormaker {
+  @manageColor
   atomColor (a: AtomProxy) {
     return ResidueColors[ a.resname ] || DefaultResidueColor
   }

--- a/src/color/selection-colormaker.ts
+++ b/src/color/selection-colormaker.ts
@@ -46,6 +46,7 @@ class SelectionColormaker extends Colormaker {
     })
   }
 
+  // NOT NEEDED @manageColor
   atomColor (a: AtomProxy) {
     for (let i = 0, n = this.selectionList.length; i < n; ++i) {
       const test = this.selectionList[ i ].test

--- a/src/color/sstruc-colormaker.ts
+++ b/src/color/sstruc-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { StuctureColormakerParams } from './colormaker'
+import Colormaker, { StuctureColormakerParams, manageColor } from './colormaker'
 import AtomProxy from '../proxy/atom-proxy'
 import ResidueProxy from '../proxy/residue-proxy'
 
@@ -37,6 +37,7 @@ class SstrucColormaker extends Colormaker {
     this.residueProxy = params.structure.getResidueProxy()
   }
 
+  @manageColor
   atomColor (ap: AtomProxy) {
     const sstruc = ap.sstruc
     const rp = this.residueProxy

--- a/src/color/uniform-colormaker.ts
+++ b/src/color/uniform-colormaker.ts
@@ -5,24 +5,28 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker from './colormaker'
+import Colormaker, { manageColor } from './colormaker'
 
 /**
  * Color by uniform color
  */
 class UniformColormaker extends Colormaker {
+  @manageColor
   atomColor () {
     return this.parameters.value
   }
 
+  @manageColor
   bondColor () {
     return this.parameters.value
   }
 
+  @manageColor
   valueColor () {
     return this.parameters.value
   }
 
+  @manageColor
   volumeColor () {
     return this.parameters.value
   }

--- a/src/color/value-colormaker.ts
+++ b/src/color/value-colormaker.ts
@@ -5,7 +5,7 @@
  */
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { VolumeColormakerParams, ColormakerScale } from './colormaker'
+import Colormaker, { VolumeColormakerParams, ColormakerScale, manageColor } from './colormaker'
 
 /**
  * Color by volume value
@@ -23,6 +23,7 @@ class ValueColormaker extends Colormaker {
    * @param  {Integer} index - volume cell index
    * @return {Integer} hex cell color
    */
+  @manageColor
   volumeColor (index: number) {
     return this.valueScale((this.parameters.volume! as any).data[ index ])  // TODO
   }

--- a/src/color/volume-colormaker.ts
+++ b/src/color/volume-colormaker.ts
@@ -8,7 +8,7 @@ import { Vector3 } from 'three'
 import { lerp } from '../math/math-utils'
 
 import { ColormakerRegistry } from '../globals'
-import Colormaker, { VolumeColormakerParams, ColormakerScale } from './colormaker'
+import Colormaker, { VolumeColormakerParams, ColormakerScale, manageColor } from './colormaker'
 
 /**
  * Color by volume position
@@ -27,6 +27,7 @@ class VolumeColormaker extends Colormaker {
    * @param  {Vector3} coords - xyz coordinates
    * @return {Integer} hex coords color
    */
+  @manageColor
   positionColor (coords: Vector3) {
     const volume = this.parameters.volume as any  // TODO
 

--- a/src/representation/representation.ts
+++ b/src/representation/representation.ts
@@ -31,6 +31,7 @@ export interface RepresentationParameters {
   colorValue: number,
   colorDomain: number[],
   colorMode: ColorMode,
+  colorSpace: 'sRGB' | 'linear',
   roughness: number,
   metalness: number,
   diffuse: Color,
@@ -374,7 +375,8 @@ class Representation {
       reverse: this.colorReverse,
       value: this.colorValue,
       domain: this.colorDomain,
-      mode: this.colorMode
+      mode: this.colorMode,
+      colorSpace: this.colorSpace,
 
     }, p)
   }

--- a/src/stage/stage.ts
+++ b/src/stage/stage.ts
@@ -326,7 +326,7 @@ class Stage {
       let colorReverse = false
       if (structure.getChainnameCount(new Selection('polymer and /0')) === 1) {
         colorScheme = 'residueindex'
-        colorScale = 'spectral'
+        colorScale = 'Spectral'
         colorReverse = true
       }
 

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -1236,7 +1236,7 @@ export default class Viewer {
     this.updateInfo()
   }
 
-  private __renderSuperSample (camera: PerspectiveCamera|OrthographicCamera) {
+  private __renderSuperSample (camera: PerspectiveCamera|OrthographicCamera, renderTarget?: WebGLRenderTarget) {
     // based on the Supersample Anti-Aliasing Render Pass
     // contributed to three.js by bhouston / http://clara.io/
     //
@@ -1289,12 +1289,12 @@ export default class Viewer {
     this.compositeUniforms.tForeground.value = this.holdTarget.texture
 
     camera.clearViewOffset()
-    this.renderer.setRenderTarget(null!)
+    this.renderer.setRenderTarget(renderTarget || null)
     this.renderer.clear()
     this.renderer.render(this.compositeScene, this.compositeCamera)
   }
 
-  private __renderStereo (picking = false) {
+  private __renderStereo (picking = false, _renderTarget?: WebGLRenderTarget) {
     const stereoCamera = this.stereoCamera
     stereoCamera.update(this.perspectiveCamera);
 
@@ -1318,18 +1318,18 @@ export default class Viewer {
     renderer.setViewport(0, 0, size.width, size.height)
   }
 
-  private __render(picking = false, camera: PerspectiveCamera|OrthographicCamera) {
+  private __render(picking = false, camera: PerspectiveCamera|OrthographicCamera, renderTarget?: WebGLRenderTarget) {
     if (picking) {
       if (!this.lastRenderedPicking) this.__renderPickingGroup(camera)
     } else if (this.sampleLevel > 0 && this.parameters.cameraType !== 'stereo') {
       // TODO super sample broken for stereo camera
-      this.__renderSuperSample(camera)
+      this.__renderSuperSample(camera, renderTarget)
     } else {
-      this.__renderModelGroup(camera)
+      this.__renderModelGroup(camera, renderTarget)
     }
   }
 
-  render (picking = false) {
+  render (picking = false, renderTarget?: WebGLRenderTarget) {
     if (this.rendering) {
       Log.warn("'tried to call 'render' from within 'render'")
       return
@@ -1347,9 +1347,9 @@ export default class Viewer {
 
       // render
       if (this.parameters.cameraType === 'stereo') {
-        this.__renderStereo(picking)
+        this.__renderStereo(picking, renderTarget)
       } else {
-        this.__render(picking, this.camera)
+        this.__render(picking, this.camera, renderTarget)
       }
       this.lastRenderedPicking = picking
     } finally {

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -323,8 +323,10 @@ export default class Viewer {
 
       sampleLevel: 0,
 
-      rendererEncoding: LinearEncoding,
-      colorEncoding: sRGBEncoding
+      // output encoding: use sRGB for a linear internal workflow, linear for traditional sRGB workflow.
+      rendererEncoding: sRGBEncoding,
+      // Linear converts colors to linear for a linear workflow. Use sRGB for traditional workflow.
+      colorEncoding: LinearEncoding
     }
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
         "strictNullChecks": true,
         "allowSyntheticDefaultImports": true,
         "experimentalDecorators": true,
+        "noEmitHelpers": true,
+        "importHelpers": true,
         "lib": [ "es6", "dom", "es2016" ],
         "allowJs": false,
         "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         "noUnusedLocals": true,
         "strictNullChecks": true,
         "allowSyntheticDefaultImports": true,
+        "experimentalDecorators": true,
         "lib": [ "es6", "dom", "es2016" ],
         "allowJs": false,
         "moduleResolution": "node",


### PR DESCRIPTION
Here's my color-management code -- linear workflow internally, turned on by default.

I've been using it for a while and it works well for me. There are two issues to discuss, I think:
1. How to allow users to specify the color encoding, if they want to go back to the default? I've added a `colorEncoding` param to the viewer, which seems like a good place for it, but I don't have a good idea on how to thread it through to colormaker.ts where it's needed. So right now that param does nothing -- in order to get back to the old workflow you have to change `colorSpace` in colormaker.ts. Ideas appreciated.

2. @arose commented in #775 that it might be better to implement color management in the shader; I'd like to propose that it's at least OK if not better to do it this way because the values (vertex colors, param values, and textures) are explicitly linear, which works properly e.g. when exporting models as glTF. The only real issue is that in colormaker.ts, it's still creating 8-bit linear color values because it uses `.toHex`. Ideally it should produce float rgb triples and use those everywhere, but that's a bigger change than I wanted to get into for this PR. It does mean you lose some precision when specifying very dark colors, but I don't think that's so bad for now; moving to full-float colors would be a good next step.