### PR TITLE
Ensure CSV parameters are not dropped when creating the CsvParser

### DIFF
--- a/src/loader/parser-loader.ts
+++ b/src/loader/parser-loader.ts
@@ -15,6 +15,9 @@ export interface ParserParams {
   cAlphaOnly?: boolean
   name?: string
   path?: string
+  delimiter?: string
+  comment?: string
+  columnNames?: string
 }
 
 /**
@@ -31,6 +34,9 @@ class ParserLoader extends Loader {
       firstModelOnly: params.firstModelOnly,
       asTrajectory: params.asTrajectory,
       cAlphaOnly: params.cAlphaOnly,
+      delimiter: params.delimiter,
+      comment: params.comment,
+      columnNames: params.columnNames,
       name: this.parameters.name,
       path: this.parameters.path
     }


### PR DESCRIPTION
The showcase/qmean example was broken (it uses a 'csv' file with space delimiter, and the relevant `delimiter` parameter was not making it all the way to the CsvParser constructor). This is now fixed. The way this is done isn't totally satisfactory (we're telling ParserLoader the names of all possible parser parameters - would make sense to just tell it those that don't need to get passed through), I'll open an issue to make this more sensible, but right now this fixes that example.


Relates tangentially to #823, I'll comment there