### PR TITLE
Explicitly check for EXT_frag_depth rather than assuming it's present…

### DIFF
--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -438,7 +438,7 @@ export default class Viewer {
 
     // If not webgl2 context, explicitly check for these
     if (!this.renderer.capabilities.isWebGL2) {
-      setExtensionFragDepth(this.renderer.capabilities.isWebGL2)
+      setExtensionFragDepth(this.renderer.extensions.get('EXT_frag_depth'))
       this.renderer.extensions.get('OES_element_index_uint')
       
       setSupportsReadPixelsFloat(


### PR DESCRIPTION
… in WebGL1 (it isn't in Safari <14)

Finally finally close #778? Maybe?
