### PR TITLE
Correctly parse atomname of form '0C21', fixes #797

### DIFF
--- a/src/structure/structure-utils.ts
+++ b/src/structure/structure-utils.ts
@@ -900,9 +900,10 @@ const elm2 = [ 'NA', 'CL', 'FE' ]
 
 export function guessElement (atomName: string) {
   let at = atomName.trim().toUpperCase()
-  if (parseInt(at.charAt(0))) at = at.substr(1)
+  // parseInt('C') -> NaN; (NaN > -1) -> false
+  if (parseInt(at.charAt(0)) > -1) at = at.substr(1)
     // parse again to check for a second integer
-  if (parseInt(at.charAt(0))) at = at.substr(1)
+  if (parseInt(at.charAt(0)) > -1) at = at.substr(1)
   const n = at.length
 
   if (n === 0) return ''


### PR DESCRIPTION
As per the title - fix the check for first char of atomname is integer in the `guessElement` function.
