### PR TITLE
Enables writing partial structures (for PDB format) as requested in #838

### DIFF
--- a/src/structure/structure.ts
+++ b/src/structure/structure.ts
@@ -450,8 +450,8 @@ class Structure implements Structure{
 
   //
 
-  getSelection (): false|Selection {
-    return false
+  getSelection (): undefined|Selection {
+    return
   }
 
   getStructure (): Structure|StructureView {

--- a/src/writer/pdb-writer.ts
+++ b/src/writer/pdb-writer.ts
@@ -118,7 +118,7 @@ export default class PdbWriter extends Writer {
           defaults(a.element, '')
         ))
         ia += 1
-      })
+      }, this.structure.getSelection() || undefined)
 
       this._records.push(sprintf('%-80s', 'ENDMDL'))
       im += 1

--- a/src/writer/pdb-writer.ts
+++ b/src/writer/pdb-writer.ts
@@ -118,7 +118,7 @@ export default class PdbWriter extends Writer {
           defaults(a.element, '')
         ))
         ia += 1
-      }, this.structure.getSelection() || undefined)
+      }, this.structure.getSelection())
 
       this._records.push(sprintf('%-80s', 'ENDMDL'))
       im += 1


### PR DESCRIPTION
Allows partial structures to be written (by passing the appropriate `StructureView` object to PdbWriter as opposed to a `Structure` object).

e.g, given a structure `struc` you can write the data for atoms '1-10':

```javascript
var sv = struc.getView(new NGL.Selection('1-10'))
var writer = new NGL.PdbWriter(sv)
writer.getData() // Text for atoms in residues 1-10
```