### PR TITLE
Update defaults: set surface type to vws, increase surface resolution

### DIFF
--- a/src/stage/stage.ts
+++ b/src/stage/stage.ts
@@ -351,13 +351,13 @@ class Stage {
             )
           )
         )
-        if (backboneOnly) scaleFactor = Math.min(scaleFactor, 0.15)
+        if (backboneOnly) scaleFactor = Math.min(scaleFactor, 0.5)
 
         component.addRepresentation('surface', {
           colorScheme, colorScale, colorReverse,
           sele: 'polymer',
-          surfaceType: 'vws',
-          probeRadius: 1.4,     // doesn't matter for vws but set anyway in case they switch
+          surfaceType: 'av',
+          probeRadius: 1.4,
           scaleFactor: scaleFactor,
           useWorker: false
         })

--- a/src/stage/stage.ts
+++ b/src/stage/stage.ts
@@ -344,10 +344,10 @@ class Stage {
       } else if ((instanceCount > 5 && sizeScore > 15000) || sizeScore > 700000) {
         let scaleFactor = (
           Math.min(
-            1.5,
+            2.0,
             Math.max(
               0.1,
-              2000 / (sizeScore / instanceCount)
+              6000 / (sizeScore / instanceCount)
             )
           )
         )
@@ -356,8 +356,8 @@ class Stage {
         component.addRepresentation('surface', {
           colorScheme, colorScale, colorReverse,
           sele: 'polymer',
-          surfaceType: 'sas',
-          probeRadius: 1.4,
+          surfaceType: 'vws',
+          probeRadius: 1.4,     // doesn't matter for vws but set anyway in case they switch
           scaleFactor: scaleFactor,
           useWorker: false
         })


### PR DESCRIPTION
This just updates a couple of defaults to be slightly nicer -- the default surface resolution is very low, which is good for performance, but I think modern systems can easily handle more triangles so why not make it look better by default? 
And it seems to me like a zero-offset van der Waals surface is a better surface default than the current 1.4Å-offset surface-accessible surface, but I'm happy to remove that if people prefer the current one.