### PR TITLE
Include Typescript declarations in published npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "url": "https://github.com/arose/ngl/issues"
   },
   "files": [
-    "dist"
+    "dist",
+    "declarations"
   ],
   "author": "Alexander Rose <alexander.rose@weirdbyte.de>",
   "contributors": [],


### PR DESCRIPTION
I noticed while using `ngl` in a Typescript project, that the Typescript compiler couldn't find `ngl`s types. After some digging I noticed that the `ngl.d.ts` file was correctly referenced in `package.json` but `tsc` complained. 

Then I checked inside the `declarations/` folder in my `node_modules/ngl` only to notice, that the folder didn't exist. This meant types can get generated but they are not published to npm. 

To fix this I added `declarations` to the `files` field in `package.json` since only the files defined there will end up published on npm. -> https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files

I'm not familiar with how `ngl` is published so maybe we need to update some pre publish scripts (?).