### PR TITLE
Add CallbackTrajectory

### DIFF
--- a/examples/scripts/interactive/callback-trajectory.js
+++ b/examples/scripts/interactive/callback-trajectory.js
@@ -1,0 +1,20 @@
+
+stage.loadFile('data://ala3.pdb').then(function (o) {
+  let position = o.structure.getAtomData({ what: { position: true } }).position
+  let count = 100
+  let radius = 0.1
+
+  o.addRepresentation('licorice')
+  o.addTrajectory(function (cb, i, atomIndices) {
+    if (typeof i === 'number') { // This is a frame request
+      let frame = Float32Array.from(position)
+      for (let j = 0; j < frame.length; j++) { // Add random displacement to positions
+        frame[j] += (2 * Math.random() - 1) * radius
+      }
+      cb(i, null, frame, count) // return the new frame
+    } else { // This is a frame count request
+      cb(count)
+    }
+  })
+  o.autoView()
+})

--- a/src/trajectory/callback-trajectory.ts
+++ b/src/trajectory/callback-trajectory.ts
@@ -1,0 +1,72 @@
+/**
+ * @file Callback Trajectory
+ * @author Tarn W. Burton <twburton@gmail.com>
+ * @private
+ */
+
+import Structure from '../structure/structure'
+import Trajectory, { TrajectoryParameters } from './trajectory'
+
+type RequestCallback = (responseCallback: Function, i?: number, atomIndices?: number[][]) => void
+
+/**
+ * Callback trajectory class. Gets data from an JavaScript function.
+ */
+class CallbackTrajectory extends Trajectory {
+  atomIndices: number[][]
+  requestCallback: RequestCallback
+
+  constructor (requestCallback: RequestCallback, structure: Structure, params: TrajectoryParameters) {
+    super('', structure, params)
+    this.requestCallback = requestCallback;
+    this._init(structure)
+  }
+
+  get type () { return 'callback' }
+
+  _makeAtomIndices () {
+    const atomIndices = []
+
+    if (this.structure.type === 'StructureView') {
+      const indices = this.structure.getAtomIndices()!  // TODO
+      const n = indices.length
+
+      let p = indices[ 0 ]
+      let q = indices[ 0 ]
+
+      for (let i = 1; i < n; ++i) {
+        const r = indices[ i ]
+
+        if (q + 1 < r) {
+          atomIndices.push([ p, q + 1 ])
+          p = r
+        }
+
+        q = r
+      }
+
+      atomIndices.push([ p, q + 1 ])
+    } else {
+      atomIndices.push([ 0, this.atomCount ])
+    }
+
+    this.atomIndices = atomIndices
+  }
+
+  _loadFrame (i: number, callback?: Function) {
+    this.requestCallback(
+      (i: number, box: ArrayLike<number>, coords: Float32Array, frameCount: number) => {
+        this._process(i, box, coords, frameCount)
+        if (typeof callback === 'function') {
+          callback()
+        }
+      }, i, this.atomIndices)
+  }
+
+  _loadFrameCount () {
+    this.requestCallback((count: number) => this._setFrameCount(count))
+  }
+}
+
+export default CallbackTrajectory
+

--- a/src/trajectory/trajectory-utils.ts
+++ b/src/trajectory/trajectory-utils.ts
@@ -10,6 +10,7 @@ import { TrajectoryParameters } from './trajectory'
 import FramesTrajectory from './frames-trajectory'
 import StructureTrajectory from './structure-trajectory'
 import RemoteTrajectory from './remote-trajectory'
+import CallbackTrajectory from './callback-trajectory'
 
 export function makeTrajectory (trajSrc: string|Frames, structure: Structure, params: TrajectoryParameters) {
   let traj
@@ -18,9 +19,12 @@ export function makeTrajectory (trajSrc: string|Frames, structure: Structure, pa
     traj = new FramesTrajectory(trajSrc, structure, params)
   } else if (!trajSrc && structure.frames) {
     traj = new StructureTrajectory(trajSrc, structure, params)
+  } else if (trajSrc && typeof trajSrc === 'function') {
+    traj = new CallbackTrajectory(trajSrc, structure, params)
   } else {
     traj = new RemoteTrajectory(trajSrc, structure, params)
   }
 
   return traj
 }
+


### PR DESCRIPTION
This PR adds a new trajectory type that gets the frame count and individual frames from a callback function. This functions like `RemoteTrajectory` but leaves details of the request mechanism up to the callback function. 

In order to request the frame count the function is called with a single argument which is a callback that accepts the frame count as its first argument.

To request an individual frame the function is called  with a callback, the frame number and the atom indices. The callback takes 4 arguments which are the frame number, the box, the frame coordinates, and an updated frame count. 

Both of these requests mirror the behavior of the http requests of `RemoteTrajectory`.

We use ngl extensively in our cando-jupyter kernel. In the past we have reused the front end code of nglview and implemented a Common Lisp backend that runs in Cando. We are currently making a transition to our own Jupyter frontend code in [ngl-clj](https://github.com/yitzchak/ngl-clj/tree/shasht) which has a more lispy object oriented interface among other things.

In order to reuse the trajectory logic in ngl (frame caching, interpolation, etc.) we are implementing a trajectory server using COMM remote calls in the Jupyter protocol. One obstacle to this is that none of the trajectory classes are exported so we cannot create a new subclass easily. 

Adding this new trajectory type enables custom remote style trajectories (like our Jupyter protocol) to be implemented while still keeping the implementation details of ngl private.

Also, since the name of this trajectory type  probably isn't very obvious a better one could certainly be chosen.

FYI @drmeister @myonkunas