### PR TITLE
Fix volume surface gen when changing isolevel so geometry gets smaller

### DIFF
--- a/src/buffer/buffer.ts
+++ b/src/buffer/buffer.ts
@@ -6,7 +6,7 @@
 
 import {
   Color, Vector3, Matrix4,
-  FrontSide, BackSide, DoubleSide, 
+  FrontSide, BackSide, DoubleSide,
   // VertexColors,
   NoBlending,
   BufferGeometry, BufferAttribute,
@@ -724,6 +724,7 @@ class Buffer {
           )
         } else {
           index.set(array)
+          index.count = length
           index.needsUpdate = length > 0
           index.updateRange.count = length
           geometry.setDrawRange(0, length)


### PR DESCRIPTION
In this case, instead of creating a new `index` attribute array, it reuses the old one, which is fine, but it didn't reset the `count`, which could cause the old triangles to be reused, causing graphics glitches. Simple fix (but it took me a long time to find it!)