### PR TITLE
Possible fix for interactive/crosslinking example on sandbox

### DIFF
--- a/examples/scripts/interactive/crosslinking.js
+++ b/examples/scripts/interactive/crosslinking.js
@@ -5,7 +5,7 @@ window.addEventListener('resize', function () {
 
 var newDiv = document.getElementById('viewport').appendChild(document.createElement('div'))
 newDiv.setAttribute('style', 'position: absolute; top: 0; left: 20px')
-newDiv.innerHTML = '<div class="controls"><h3>Example Cross-Links over Human Serum Albumin</h3><p class="credit">Data courtessy of Adam Belsom, Rappsilber Lab</p><p>Cross-Link Quality Filter </p><span id="minValue"></span><input type="range" min="0" max="10" step="0.1" value="0" id="scoreSlider" class="mySlider"></input><span id="maxValue"></span></div>'
+newDiv.innerHTML = `<div class="controls"><h3>Example Cross-Links over Human Serum Albumin</h3><p class="credit">Data courtessy of Adam Belsom, Rappsilber Lab</p><p>Cross-Link Quality Filter </p><span id="minValue"></span><input type="range" min="0" max="10" step="0.1" value="0" id="scoreSlider" class="mySlider"></input><span id="maxValue"></span></div>`
 
 // example crosslink data
 var links = [{


### PR DESCRIPTION
Currently the interactive/crosslinking example codesandbox is a blank screen

It has nested double quotes in a string, which is a syntax error. This PR proposes changing it to use a template string

Not clear why it was changed to double strings in the code sandbox or why it didn't escape the double quotes, but I thought using template strings may be a workaround

