### PR TITLE
Fix for cylinder impostors in orthographic code

### DIFF
--- a/src/buffer/mappedalignedbox-buffer.ts
+++ b/src/buffer/mappedalignedbox-buffer.ts
@@ -7,6 +7,17 @@
 import { BufferParameters, BufferData } from './buffer'
 import MappedBuffer from './mapped-buffer'
 
+//       +Y   /
+//    0**********2
+//    *   | /   **
+//    *   |/   * *
+// -----------3---- +X
+//    *  /|   *  *
+//    * / |   *  *
+//    1/**|******4
+//    /   |   * *
+//   /    |   **  
+//  +Z    |   5 
 const mapping = new Float32Array([
   -1.0, 1.0, -1.0,
   -1.0, -1.0, -1.0,

--- a/src/shader/CylinderImpostor.vert
+++ b/src/shader/CylinderImpostor.vert
@@ -30,12 +30,12 @@ attribute vec3 position1;
 attribute vec3 position2;
 attribute float radius;
 
-varying vec3 axis;
-varying vec4 base_radius;
-varying vec4 end_b;
-varying vec3 U;
-varying vec3 V;
-varying vec4 w;
+varying vec3 axis; // Cylinder axis
+varying vec4 base_radius; // base position and cylinder radius packed into a vec4
+varying vec4 end_b; // End position and "b" flag which indicates whether pos1/2 is flipped
+varying vec3 U; // axis, U, V form orthogonal basis aligned to the cylinder
+varying vec3 V; 
+varying vec4 w; // The position of the vertex after applying the mapping
 
 #ifdef PICKING
     #include unpack_color
@@ -61,24 +61,32 @@ void main(){
         vColor2 = color2;
     #endif
 
-    // vRadius = radius;
+    // Pack the radius
     base_radius.w = radius * matrixScale( modelViewMatrix );
 
-    vec3 center = position;
-    vec3 dir = normalize( position2 - position1 );
-    float ext = length( position2 - position1 ) / 2.0;
+    // position is supplied by mapped-buffer.ts as midpoint of position1 and 2
+    vec3 center = position; 
 
+    vec3 dir = normalize( position2 - position1 );
+    float ext = length( position2 - position1 ) / 2.0; // Half-length of cylinder
+
+    // Determine which direction the camera is in (in molecule coords)
     // using cameraPosition fails on some machines, not sure why
     // vec3 cam_dir = normalize( cameraPosition - mix( center, vec3( 0.0 ), ortho ) );
     vec3 cam_dir;
     if( ortho == 0.0 ){
         cam_dir = ( modelViewMatrixInverse * vec4( 0, 0, 0, 1 ) ).xyz - center;
+        // Equivalent to, but see note above
+        // cam_dir = normalize( cameraPosition - center );
     }else{
+        // Orthographic camera looks along -Z
         cam_dir = ( modelViewMatrixInverse * vec4( 0, 0, 1, 0 ) ).xyz;
     }
     cam_dir = normalize( cam_dir );
 
-    vec3 ldir;
+    // ldir is the cylinder's direction (center->end) in model coords
+    // It will always point towards the camera
+    vec3 ldir; 
 
     float b = dot( cam_dir, dir );
     end_b.w = b;
@@ -89,22 +97,27 @@ void main(){
     else
         ldir = ext * dir;
 
-    vec3 left = normalize( cross( cam_dir, ldir ) );
-    left = radius * left;
+    // left, up and ldir are orthogonal coordinates aligned with cylinder (ldir)
+    // scaled to the length and radius of the box
+    vec3 left = radius * normalize( cross( cam_dir, ldir ) );
     vec3 up = radius * normalize( cross( left, ldir ) );
 
-    // transform to modelview coordinates
+
+    // Normalized versions of ldir, up and left, these can be used to convert
+    // from modelView <-> cylinder-aligned
     axis = normalize( normalMatrix * ldir );
     U = normalize( normalMatrix * up );
     V = normalize( normalMatrix * left );
 
+    // Transform the base (the distant cap) and pack its coordinate
     vec4 base4 = modelViewMatrix * vec4( center - ldir, 1.0 );
     base_radius.xyz = base4.xyz / base4.w;
 
-    vec4 top_position = modelViewMatrix * vec4( center + ldir, 1.0 );
-    vec4 end4 = top_position;
+    // Similarly with the end (the near cap)
+    vec4 end4 = modelViewMatrix * vec4( center + ldir, 1.0 );
     end_b.xyz = end4.xyz / end4.w;
 
+    // w is effective coordinate (apply the mapping)
     w = modelViewMatrix * vec4(
         center + mapping.x*ldir + mapping.y*left + mapping.z*up, 1.0
     );
@@ -112,6 +125,7 @@ void main(){
     gl_Position = projectionMatrix * w;
 
     // avoid clipping (1.0 seems to induce flickering with some drivers)
+    // Is this required?
     gl_Position.z = 0.99;
 
 }


### PR DESCRIPTION
This should fix the bug @giagitom reported (closes #883) with missing cylinder caps (and interiors) in orthographic mode.

The diff is bigger than it needs to be as it took me a while and a few comments to grok what was going on, and I thought I might as well leave the comments in (and simplify the code in a few places) for when I inevitably have to look at it again :)

The critical change is removal of line: https://github.com/nglviewer/ngl/blob/3bc074b027a07b065b2dcb8da1083fff14004b3c/src/shader/CylinderImpostor.frag#L131
