### PR TITLE
Fix hovering behavior when using synthetic events in Firefox

### DIFF
--- a/src/stage/mouse-observer.ts
+++ b/src/stage/mouse-observer.ts
@@ -456,13 +456,13 @@ class MouseObserver {
 
   _setCanvasPosition (event: any) {  // TODO
     const box = this.domElement.getBoundingClientRect()
-    let offsetX, offsetY
-    if ('offsetX' in event && 'offsetY' in event) {
+    let offsetX, offsetY;
+    if ('clientX' in event && 'clientY' in event) {
+      offsetX = event.clientX - left
+      offsetY = event.clientY - top
+    } else {
       offsetX = event.offsetX
       offsetY = event.offsetY
-    } else {
-      offsetX = event.clientX - box.left
-      offsetY = event.clientY - box.top
     }
     this.canvasPosition.set(offsetX, box.height - offsetY)
   }

--- a/src/stage/mouse-observer.ts
+++ b/src/stage/mouse-observer.ts
@@ -458,8 +458,8 @@ class MouseObserver {
     const box = this.domElement.getBoundingClientRect()
     let offsetX, offsetY;
     if ('clientX' in event && 'clientY' in event) {
-      offsetX = event.clientX - left
-      offsetY = event.clientY - top
+      offsetX = event.clientX - box.left
+      offsetY = event.clientY - box.top
     } else {
       offsetX = event.offsetX
       offsetY = event.offsetY


### PR DESCRIPTION
## Background
The current behavior in `MouseObserver#_setCanvasPosition` prefers offsetX/offsetY instead of the calculation using clientX/clientY as the latter did not work in Safari (https://github.com/nglviewer/ngl/commit/fd97378a3e966724fb8049a5064fc39134997f03). Presumably this is due to Safari's [lack of support of clientX/clientY on touch events](https://caniuse.com/mdn-api_touch_clientx).

## Rationale
In my use case, I am using NGL in an offscreen canvas, rendering the result to a separate canvas I already have for my application, and then forwarding events from my canvas to NGL. However, for some reason (which I don't completely understand, though likely a browser bug or undefined behavior) when I create a synthetic mouse event in Firefox, the offsetX and offsetY are set to 0 (in Chrome, both values are properly computed). Because of the preference of using the offset values, this leads to hover events not properly working in Firefox.

## Change
I have flipped the implementation of this fallback to use clientX and clientY when available, but otherwise fall back to offsetX and offsetY. This is likely the original intent (the only browsers that support the prior but not the latter are [Firefox 18-23 and it was removed due to compatibility issues](https://caniuse.com/mdn-api_touch_clientx)), and means that the improper offset behavior in Firefox synthetic events is avoided. I don't have a Mac on hand to test with, but I did test using Gnome Web/Epiphany which is also WebKit-based.