### PR TITLE
Use label_seq_id if auth_seq_id is not present in CIF

### DIFF
--- a/src/parser/cif-parser.ts
+++ b/src/parser/cif-parser.ts
@@ -760,7 +760,7 @@ class CifParser extends StructureParser {
     var first: boolean|null = null
     var pointerNames: string[] = []
 
-    var authAsymId: number, authSeqId: number,
+    var authAsymId: number, authSeqId: number, labelSeqId: number,
       labelAtomId: number, labelCompId: number, labelAsymId: number, labelEntityId: number, labelAltId: number,
       groupPDB: number, id: number, typeSymbol: number, pdbxPDBmodelNum: number, pdbxPDBinsCode: number,
       CartnX: number, CartnY: number, CartnZ: number, bIsoOrEquiv: number, occupancy: number
@@ -904,7 +904,7 @@ class CifParser extends StructureParser {
               if (first) {
                 authAsymId = pointerNames.indexOf('auth_asym_id')
                 authSeqId = pointerNames.indexOf('auth_seq_id')
-                if (authSeqId === -1) authSeqId = pointerNames.indexOf('label_seq_id')
+                labelSeqId = pointerNames.indexOf('label_seq_id')
                 labelAtomId = pointerNames.indexOf('label_atom_id')
                 labelCompId = pointerNames.indexOf('label_comp_id')
                 labelAsymId = pointerNames.indexOf('label_asym_id')
@@ -978,7 +978,7 @@ class CifParser extends StructureParser {
               //
 
               const resname = ls[ labelCompId ]
-              const resno = parseInt(ls[ authSeqId ])
+              const resno = parseInt(ls[ authSeqId !== -1 ? authSeqId : labelSeqId ])
               let inscode = ls[ pdbxPDBinsCode ]
               inscode = (inscode === '?') ? '' : inscode
               const chainname = ls[ authAsymId ]

--- a/src/parser/cif-parser.ts
+++ b/src/parser/cif-parser.ts
@@ -904,6 +904,7 @@ class CifParser extends StructureParser {
               if (first) {
                 authAsymId = pointerNames.indexOf('auth_asym_id')
                 authSeqId = pointerNames.indexOf('auth_seq_id')
+                if (authSeqId === -1) authSeqId = pointerNames.indexOf('label_seq_id')
                 labelAtomId = pointerNames.indexOf('label_atom_id')
                 labelCompId = pointerNames.indexOf('label_comp_id')
                 labelAsymId = pointerNames.indexOf('label_asym_id')


### PR DESCRIPTION
Per https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_atom_site.auth_seq_id.html, auth_seq_id is an alternative numbering to match a publication, whereas label_seq_id is a sequential identifier. It is possible to have CIF files with the latter, but not the former (in my case, the file I was using was created by extracting the chain chain LB from PDB 3J9Z in PyMOL, then exported to CIF).

Related: #696