### PR TITLE
Don't mutate colorDomain in place when colorReverse is true

### DIFF
--- a/src/color/colormaker.ts
+++ b/src/color/colormaker.ts
@@ -119,7 +119,7 @@ abstract class Colormaker {
     }
 
     if (p.reverse) {
-      p.domain.reverse()
+      p.domain = p.domain.slice().reverse()
     }
     return chroma
       .scale(p.scale as any)  // TODO


### PR DESCRIPTION
Very small change. Previously, if colorDomain and colorReverse were set, the colorDomain array would be reversed in place (in the colormaker's scale creation step). If the representation requires multiple instances of colormaker (e.g. ball+stick) then theeven numbered ones appear with the color reversed:

https://codepen.io/fludlow/pen/KKXjRwY

This fix copies the array before reversing it (so the original one isn't mutated)