### PR TITLE
Export representation classes to allow for extension

### DIFF
--- a/src/ngl.ts
+++ b/src/ngl.ts
@@ -87,31 +87,32 @@ import './component/volume-component'
 
 //
 
-import './representation/angle-representation'
-import './representation/axes-representation'
-import './representation/backbone-representation'
-import './representation/ballandstick-representation'
-import './representation/base-representation'
-import './representation/cartoon-representation'
-import './representation/contact-representation'
-import './representation/dihedral-representation'
-import './representation/dihedral-histogram-representation'
-import './representation/distance-representation'
-import './representation/helixorient-representation'
-import './representation/hyperball-representation'
-import './representation/label-representation'
-import './representation/licorice-representation'
-import './representation/line-representation'
-import './representation/molecularsurface-representation'
-import './representation/point-representation'
-import './representation/ribbon-representation'
-import './representation/rocket-representation'
-import './representation/rope-representation'
-import './representation/spacefill-representation'
-import './representation/trace-representation'
-import './representation/tube-representation'
-import './representation/unitcell-representation'
-import './representation/validation-representation'
+import AngleRepresentation, {AngleRepresentationParameters} from './representation/angle-representation'
+import AxesRepresentation, {AxesRepresentationParameters} from './representation/axes-representation'
+import BackboneRepresentation from './representation/backbone-representation'
+import BallAndStickRepresentation, {BallAndStickRepresentationParameters} from './representation/ballandstick-representation'
+import BaseRepresentation from './representation/base-representation'
+import CartoonRepresentation, {CartoonRepresentationParameters} from './representation/cartoon-representation'
+import ContactRepresentation, {ContactRepresentationParameters} from './representation/contact-representation'
+import DihedralRepresentation, {DihedralRepresentationParameters} from './representation/dihedral-representation'
+import DihedralHistogramRepresentation, {DihedralHistogramRepresentationParameters} from './representation/dihedral-histogram-representation'
+import DistanceRepresentation, {DistanceRepresentationParameters} from './representation/distance-representation'
+import HelixorientRepresentation from './representation/helixorient-representation'
+import HyperballRepresentation, {HyperballRepresentationParameters} from './representation/hyperball-representation'
+import LabelRepresentation, {LabelRepresentationParameters} from './representation/label-representation'
+import LicoriceRepresentation from './representation/licorice-representation'
+import LineRepresentation, {LineRepresentationParameters} from './representation/line-representation'
+import MolecularSurfaceRepresentation, {MolecularSurfaceRepresentationParameters} from './representation/molecularsurface-representation'
+import PointRepresentation, {PointRepresentationParameters} from './representation/point-representation'
+import RibbonRepresentation, {RibbonRepresentationParameters} from './representation/ribbon-representation'
+import RocketRepresentation, {RocketRepresentationParameters} from './representation/rocket-representation'
+import RopeRepresentation from './representation/rope-representation'
+import SpacefillRepresentation from './representation/spacefill-representation'
+import StructureRepresentation, {StructureRepresentationParameters} from './representation/structure-representation'
+import TraceRepresentation, {TraceRepresentationParameters} from './representation/trace-representation'
+import TubeRepresentation from './representation/tube-representation'
+import UnitcellRepresentation, {UnitcellRepresentationParameters} from './representation/unitcell-representation'
+import ValidationRepresentation from './representation/validation-representation'
 
 import BufferRepresentation from './representation/buffer-representation'
 import ArrowBuffer from './buffer/arrow-buffer'
@@ -250,6 +251,51 @@ export {
 
   Queue,
   Counter,
+
+  AngleRepresentation,
+  AngleRepresentationParameters,
+  AxesRepresentation,
+  AxesRepresentationParameters,
+  BackboneRepresentation,
+  BallAndStickRepresentation,
+  BallAndStickRepresentationParameters,
+  BaseRepresentation,
+  CartoonRepresentation,
+  CartoonRepresentationParameters,
+  ContactRepresentation,
+  ContactRepresentationParameters,
+  DihedralRepresentation,
+  DihedralRepresentationParameters,
+  DihedralHistogramRepresentation,
+  DihedralHistogramRepresentationParameters,
+  DistanceRepresentation,
+  DistanceRepresentationParameters,
+  HelixorientRepresentation,
+  HyperballRepresentation,
+  HyperballRepresentationParameters,
+  LabelRepresentation,
+  LabelRepresentationParameters,
+  LicoriceRepresentation,
+  LineRepresentation,
+  LineRepresentationParameters,
+  MolecularSurfaceRepresentation,
+  MolecularSurfaceRepresentationParameters,
+  PointRepresentation,
+  PointRepresentationParameters,
+  RibbonRepresentation,
+  RibbonRepresentationParameters,
+  RocketRepresentation,
+  RocketRepresentationParameters,
+  RopeRepresentation,
+  SpacefillRepresentation,
+  StructureRepresentation,
+  StructureRepresentationParameters,
+  TraceRepresentation,
+  TraceRepresentationParameters,
+  TubeRepresentation,
+  UnitcellRepresentation,
+  UnitcellRepresentationParameters,
+  ValidationRepresentation,
 
   BufferRepresentation,
   ArrowBuffer,


### PR DESCRIPTION
I'm creating a custom StructureRepresentation for my embedded NGL viewer, where I want to extend the StructureRepresentation class. I've gone ahead and exported all representations and their parameters as well, as if someone wants to make a representation based on an existing representation, those are also exposed.