### PR TITLE
Improve typing of "impostorable" buffers

### DIFF
--- a/src/buffer/cylinder-buffer.ts
+++ b/src/buffer/cylinder-buffer.ts
@@ -38,7 +38,7 @@ export type CylinderBufferParameters = typeof CylinderBufferDefaultParameters
  *   radius: new Float32Array([ 1 ])
  * });
  */
-class CylinderBuffer {
+class CylinderBufferImpl {
   constructor (data: CylinderBufferData, params: Partial<CylinderBufferParameters> = {}) {
     if (!data.color2 && data.color) data.color2 = data.color
     if (!ExtensionFragDepth || (params && params.disableImpostor)) {
@@ -48,6 +48,12 @@ class CylinderBuffer {
     }
   }
 }
+
+const CylinderBuffer: {
+  new(data: CylinderBufferData, params: Partial<CylinderBufferParameters>): CylinderGeometryBuffer | CylinderImpostorBuffer;
+} = CylinderBufferImpl as any;
+
+type CylinderBuffer = CylinderGeometryBuffer | CylinderImpostorBuffer;
 
 BufferRegistry.add('cylinder', CylinderBuffer)
 

--- a/src/buffer/cylinder-buffer.ts
+++ b/src/buffer/cylinder-buffer.ts
@@ -23,6 +23,17 @@ export const CylinderBufferDefaultParameters = Object.assign({
 }, CylinderGeometryBufferDefaultParameters, CylinderImpostorBufferDefaultParameters)
 export type CylinderBufferParameters = typeof CylinderBufferDefaultParameters
 
+class CylinderBufferImpl {
+  constructor (data: CylinderBufferData, params: Partial<CylinderBufferParameters> = {}) {
+    if (!data.color2 && data.color) data.color2 = data.color
+    if (!ExtensionFragDepth || (params && params.disableImpostor)) {
+      return new CylinderGeometryBuffer(data, params)
+    } else {
+      return new CylinderImpostorBuffer(data, params)
+    }
+  }
+}
+
 /**
  * Cylinder buffer. Depending on the value {@link ExtensionFragDepth} and
  * `params.disableImpostor` the constructor returns either a
@@ -38,20 +49,10 @@ export type CylinderBufferParameters = typeof CylinderBufferDefaultParameters
  *   radius: new Float32Array([ 1 ])
  * });
  */
-class CylinderBufferImpl {
-  constructor (data: CylinderBufferData, params: Partial<CylinderBufferParameters> = {}) {
-    if (!data.color2 && data.color) data.color2 = data.color
-    if (!ExtensionFragDepth || (params && params.disableImpostor)) {
-      return new CylinderGeometryBuffer(data, params)
-    } else {
-      return new CylinderImpostorBuffer(data, params)
-    }
-  }
-}
-
+//@ts-expect-error Incompatible constructor signatures
 const CylinderBuffer: {
   new(data: CylinderBufferData, params: Partial<CylinderBufferParameters>): CylinderGeometryBuffer | CylinderImpostorBuffer;
-} = CylinderBufferImpl as any;
+} = CylinderBufferImpl;
 
 type CylinderBuffer = CylinderGeometryBuffer | CylinderImpostorBuffer;
 

--- a/src/buffer/hyperballstick-buffer.ts
+++ b/src/buffer/hyperballstick-buffer.ts
@@ -25,22 +25,6 @@ export const HyperballStickBufferDefaultParameters = Object.assign({
 }, CylinderGeometryBufferDefaultParameters, HyperballStickImpostorBufferDefaultParameters)
 export type HyperballStickBufferParameters = typeof HyperballStickBufferDefaultParameters
 
-/**
- * Hyperball stick buffer. Depending on the value {@link ExtensionFragDepth} and
- * `params.disableImpostor` the constructor returns either a
- * {@link CylinderGeometryBuffer} or a {@link HyperballStickImpostorBuffer}
- * @implements {Buffer}
- *
- * @example
- * var hyperballStickBuffer = new HyperballStickBuffer({
- *   position1: new Float32Array([ 0, 0, 0 ]),
- *   position2: new Float32Array([ 2, 2, 2 ]),
- *   color: new Float32Array([ 1, 0, 0 ]),
- *   color2: new Float32Array([ 0, 1, 0 ]),
- *   radius: new Float32Array([ 1 ]),
- *   radius2: new Float32Array([ 2 ])
- * });
- */
 class HyperballStickBufferImpl {
   /**
    * @param  {Object} data - attribute object
@@ -63,9 +47,26 @@ class HyperballStickBufferImpl {
   }
 }
 
+/**
+ * Hyperball stick buffer. Depending on the value {@link ExtensionFragDepth} and
+ * `params.disableImpostor` the constructor returns either a
+ * {@link CylinderGeometryBuffer} or a {@link HyperballStickImpostorBuffer}
+ * @implements {Buffer}
+ *
+ * @example
+ * var hyperballStickBuffer = new HyperballStickBuffer({
+ *   position1: new Float32Array([ 0, 0, 0 ]),
+ *   position2: new Float32Array([ 2, 2, 2 ]),
+ *   color: new Float32Array([ 1, 0, 0 ]),
+ *   color2: new Float32Array([ 0, 1, 0 ]),
+ *   radius: new Float32Array([ 1 ]),
+ *   radius2: new Float32Array([ 2 ])
+ * });
+ */
+//@ts-expect-error Incompatible constructor signatures
 const HyperballStickBuffer: {
   new(data: HyperballStickBufferData, params: Partial<HyperballStickBufferParameters>): CylinderGeometryBuffer | HyperballStickImpostorBuffer;
-} = HyperballStickBufferImpl as any;
+} = HyperballStickBufferImpl;
 
 type HyperballStickBuffer = CylinderGeometryBuffer | HyperballStickImpostorBuffer;
 

--- a/src/buffer/hyperballstick-buffer.ts
+++ b/src/buffer/hyperballstick-buffer.ts
@@ -41,7 +41,7 @@ export type HyperballStickBufferParameters = typeof HyperballStickBufferDefaultP
  *   radius2: new Float32Array([ 2 ])
  * });
  */
-class HyperballStickBuffer {
+class HyperballStickBufferImpl {
   /**
    * @param  {Object} data - attribute object
    * @param  {Float32Array} data.position1 - from positions
@@ -62,5 +62,11 @@ class HyperballStickBuffer {
     }
   }
 }
+
+const HyperballStickBuffer: {
+  new(data: HyperballStickBufferData, params: Partial<HyperballStickBufferParameters>): CylinderGeometryBuffer | HyperballStickImpostorBuffer;
+} = HyperballStickBufferImpl as any;
+
+type HyperballStickBuffer = CylinderGeometryBuffer | HyperballStickImpostorBuffer;
 
 export default HyperballStickBuffer

--- a/src/buffer/sphere-buffer.ts
+++ b/src/buffer/sphere-buffer.ts
@@ -20,19 +20,6 @@ export const SphereBufferDefaultParameters = Object.assign({
 }, SphereGeometryBufferDefaultParameters)
 export type SphereBufferParameters = typeof SphereBufferDefaultParameters
 
-/**
- * Sphere buffer. Depending on the value {@link ExtensionFragDepth} and
- * `params.disableImpostor` the constructor returns either a
- * {@link SphereGeometryBuffer} or a {@link SphereImpostorBuffer}
- * @implements {Buffer}
- *
- * @example
- * var sphereBuffer = new SphereBuffer( {
- *     position: new Float32Array( [ 0, 0, 0 ] ),
- *     color: new Float32Array( [ 1, 0, 0 ] ),
- *     radius: new Float32Array( [ 1 ] )
- * } );
- */
 class SphereBufferImpl {
     /**
      * @param {Object} data - buffer data
@@ -52,9 +39,23 @@ class SphereBufferImpl {
   }
 }
 
+/**
+ * Sphere buffer. Depending on the value {@link ExtensionFragDepth} and
+ * `params.disableImpostor` the constructor returns either a
+ * {@link SphereGeometryBuffer} or a {@link SphereImpostorBuffer}
+ * @implements {Buffer}
+ *
+ * @example
+ * var sphereBuffer = new SphereBuffer( {
+ *     position: new Float32Array( [ 0, 0, 0 ] ),
+ *     color: new Float32Array( [ 1, 0, 0 ] ),
+ *     radius: new Float32Array( [ 1 ] )
+ * } );
+ */
+//@ts-expect-error Incompatible constructor signatures
 const SphereBuffer: {
   new(data: SphereBufferData, params: SphereBufferParameters): SphereGeometryBuffer | SphereImpostorBuffer;
-} = SphereBufferImpl as any;
+} = SphereBufferImpl;
 
 type SphereBuffer = SphereGeometryBuffer | SphereImpostorBuffer;
 

--- a/src/buffer/sphere-buffer.ts
+++ b/src/buffer/sphere-buffer.ts
@@ -33,7 +33,7 @@ export type SphereBufferParameters = typeof SphereBufferDefaultParameters
  *     radius: new Float32Array( [ 1 ] )
  * } );
  */
-class SphereBuffer {
+class SphereBufferImpl {
     /**
      * @param {Object} data - buffer data
      * @param {Float32Array} data.position - positions
@@ -51,6 +51,12 @@ class SphereBuffer {
     }
   }
 }
+
+const SphereBuffer: {
+  new(data: SphereBufferData, params: SphereBufferParameters): SphereGeometryBuffer | SphereImpostorBuffer;
+} = SphereBufferImpl as any;
+
+type SphereBuffer = SphereGeometryBuffer | SphereImpostorBuffer;
 
 BufferRegistry.add('sphere', SphereBuffer)
 


### PR DESCRIPTION
This PR allows instances of CylinderBuffer to be properly be typed as a `CylinderGeometryBuffer | CylinderImpostorBuffer`, as that's what the constructor returns.

FWIW: I'm not a fan of the `as any` casting as it avoids proper type checking. It might be preferable to change the API here to be a static method instead.