### PR TITLE
Fix crash when using alternate materials (eg when using outline effect)

### DIFF
--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -58,6 +58,8 @@ function onBeforeRender (this: Object3D, renderer: WebGLRenderer, scene: Scene, 
   const u = material.uniforms
   const updateList = []
 
+  if (!u) return
+
   if (u.objectId) {
     u.objectId.value = SupportsReadPixelsFloat ? this.id : this.id / 255
     updateList.push('objectId')

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -58,7 +58,7 @@ function onBeforeRender (this: Object3D, renderer: WebGLRenderer, scene: Scene, 
   const u = material.uniforms
   const updateList = []
 
-  if (!u) return
+  if (!u) return  // See #908 - some materials may not have uniforms, ignore these
 
   if (u.objectId) {
     u.objectId.value = SupportsReadPixelsFloat ? this.id : this.id / 255


### PR DESCRIPTION
In my app, I've integrated rendering using EffectComposer, including an OutlinePass. The OutlinePass relies on rendering with special materials, which are not `ShaderMaterial`s and as such do not have the uniforms property.

Let me know if there's a better way to handle this (and if I should change the type of `material` to `Material`)