### PR TITLE
Enable three.js treeshaking with three-minifier-rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "ngl",
-      "version": "2.0.0-dev.39",
+      "version": "2.0.0-dev.40",
       "license": "MIT",
       "dependencies": {
         "chroma-js": "^1.3.7",
@@ -31,6 +31,7 @@
         "@types/promise-polyfill": "^6.0.0",
         "@types/signals": "1.0.1",
         "@types/sprintf-js": "^1.1.2",
+        "@yushijinhun/three-minifier-rollup": "^0.3.1",
         "babel-plugin-array-includes": "^2.0.3",
         "babelrc-rollup": "^3.0.0",
         "cpy-cli": "^3.1.0",
@@ -2956,6 +2957,48 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
+    },
+    "node_modules/@yushijinhun/three-minifier-common": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@yushijinhun/three-minifier-common/-/three-minifier-common-0.3.1.tgz",
+      "integrity": "sha512-q7onzeFsyW9Cemu+YBcJphA47lnJ673HwronZIY3jLPZg4AlI65bX5g6z5QAAn3FPS5ALm/HEbu/+6Hw+nhXpw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0",
+        "glsl-tokenizer": "^2.1.5"
+      }
+    },
+    "node_modules/@yushijinhun/three-minifier-common/node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@yushijinhun/three-minifier-common/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@yushijinhun/three-minifier-rollup": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@yushijinhun/three-minifier-rollup/-/three-minifier-rollup-0.3.1.tgz",
+      "integrity": "sha512-SiRitwk4FNhYWzAgVGZh+lU6fNnN+y6UjUs4ipYVZG1dlO7jDLXb2favNIA8w+8DywR9vvoK9lvqgcT0tJtudg==",
+      "dev": true,
+      "dependencies": {
+        "@yushijinhun/three-minifier-common": "^0.3.1",
+        "magic-string": "^0.25.7"
+      }
     },
     "node_modules/abab": {
       "version": "2.0.5",
@@ -6291,6 +6334,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/glsl-tokenizer": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
+      "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
+      "dev": true,
+      "dependencies": {
+        "through2": "^0.6.3"
       }
     },
     "node_modules/graceful-fs": {
@@ -13075,6 +13127,40 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "node_modules/through2": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -16131,6 +16217,41 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
+    "@yushijinhun/three-minifier-common": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@yushijinhun/three-minifier-common/-/three-minifier-common-0.3.1.tgz",
+      "integrity": "sha512-q7onzeFsyW9Cemu+YBcJphA47lnJ673HwronZIY3jLPZg4AlI65bX5g6z5QAAn3FPS5ALm/HEbu/+6Hw+nhXpw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0",
+        "glsl-tokenizer": "^2.1.5"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+          "dev": true
+        },
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        }
+      }
+    },
+    "@yushijinhun/three-minifier-rollup": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@yushijinhun/three-minifier-rollup/-/three-minifier-rollup-0.3.1.tgz",
+      "integrity": "sha512-SiRitwk4FNhYWzAgVGZh+lU6fNnN+y6UjUs4ipYVZG1dlO7jDLXb2favNIA8w+8DywR9vvoK9lvqgcT0tJtudg==",
+      "dev": true,
+      "requires": {
+        "@yushijinhun/three-minifier-common": "^0.3.1",
+        "magic-string": "^0.25.7"
+      }
+    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -18738,6 +18859,15 @@
         "ignore": "^4.0.3",
         "pify": "^4.0.1",
         "slash": "^2.0.0"
+      }
+    },
+    "glsl-tokenizer": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
+      "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
+      "dev": true,
+      "requires": {
+        "through2": "^0.6.3"
       }
     },
     "graceful-fs": {
@@ -23979,6 +24109,42 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "through2": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "dev": true,
+      "requires": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/promise-polyfill": "^6.0.0",
     "@types/signals": "1.0.1",
     "@types/sprintf-js": "^1.1.2",
+    "@yushijinhun/three-minifier-rollup": "^0.3.1",
     "babel-plugin-array-includes": "^2.0.3",
     "babelrc-rollup": "^3.0.0",
     "cpy-cli": "^3.1.0",

--- a/rollup.config.dist.js
+++ b/rollup.config.dist.js
@@ -26,21 +26,13 @@ const minModuleConfig = {
 const minBundleConfig = {
   input: 'src/ngl.ts',
   plugins: [ threeMinifier(), ...plugins, terser()],
-  output: [{
-    file: 'dist/ngl.bundle.umd.js',
+  output: {
+    file: 'dist/ngl.js',
     format: 'umd',
     name: 'NGL',
     sourcemap: true,
     globals: {}
   },
-  {
-    file: 'dist/ngl.bundle.esm.js',
-    format: 'es',
-    name: 'NGL',
-    sourcemap: true,
-    globals: {}
-  },
-  ],
   external: []
 }
 

--- a/rollup.config.dist.js
+++ b/rollup.config.dist.js
@@ -1,4 +1,3 @@
-import internal from 'rollup-plugin-internal'
 import { terser } from 'rollup-plugin-terser'
 import { plugins, moduleGlobals, umdGlobals, moduleExternals } from './rollup.config.js'
 import { threeMinifier } from "@yushijinhun/three-minifier-rollup";

--- a/rollup.config.dist.js
+++ b/rollup.config.dist.js
@@ -1,6 +1,7 @@
 import internal from 'rollup-plugin-internal'
 import { terser } from 'rollup-plugin-terser'
 import { plugins, moduleGlobals, umdGlobals, moduleExternals } from './rollup.config.js'
+import { threeMinifier } from "@yushijinhun/three-minifier-rollup";
 
 const minModuleConfig = {
   input: 'src/ngl.ts',
@@ -25,14 +26,22 @@ const minModuleConfig = {
 
 const minBundleConfig = {
   input: 'src/ngl.ts',
-  plugins: [...plugins, internal(['three']), terser()],
-  output: {
-    file: 'dist/ngl.js',
+  plugins: [ threeMinifier(), ...plugins, terser()],
+  output: [{
+    file: 'dist/ngl.bundle.umd.js',
     format: 'umd',
     name: 'NGL',
     sourcemap: true,
     globals: {}
   },
+  {
+    file: 'dist/ngl.bundle.esm.js',
+    format: 'es',
+    name: 'NGL',
+    sourcemap: true,
+    globals: {}
+  },
+  ],
   external: []
 }
 


### PR DESCRIPTION
This reduces the bundle size by a few hundred kb. I added the bundle both as ESM and UMD.

It would be nice if ngl itself could be treeshaken, e.g., the parsers and representations are quite large.
