### PR TITLE
fix: don't dispose structure

### DIFF
--- a/src/representation/structure-representation.ts
+++ b/src/representation/structure-representation.ts
@@ -396,7 +396,6 @@ abstract class StructureRepresentation extends Representation {
 
   dispose () {
     this.structureView.dispose()
-    this.structure.dispose()
 
     super.dispose()
   }


### PR DESCRIPTION
This is a fix for a regression introduced in 3405abbd0a8ec1de35aa63d0e90126beb5d07b44.

I went through the code and noticed that in commit 3405abbd0a8ec1de35aa63d0e90126beb5d07b44 the file [`structure-representation.ts`](https://github.com/nglviewer/ngl/commit/3405abbd0a8ec1de35aa63d0e90126beb5d07b44#diff-09bd4aa7341d7b6b788671287da35019dd485d4d6849f6eb0c91da2553523bf1) was changed. Even though the commit was supposed to only update new Typescript rules it changed behaviour, causing the bug.

---

When updating `ngl` in our project from `2.0.0-dev.39` to `2.0.0-dev.40` I noticed that adding new representations after removing old ones didn't work anymore. The old representations were simply removed and new ones didn't appear in the viewer.

It is working as expected in version `2.0.0-dev.39` as you can see in this Codesandbox:  
https://codesandbox.io/s/pedantic-dan-z9ycdv

https://user-images.githubusercontent.com/5798652/183840658-6c47f0d5-4a7a-4844-b015-57cb7e3bd640.mp4

After installing version `2.0.0-dev.40` (it happens in `2.0.0` too but that isn't available on npm) it looks like this:
https://codesandbox.io/s/upbeat-danny-o5td2v

https://user-images.githubusercontent.com/5798652/183840902-874b6e74-e0d1-413a-840d-a3660bec973e.mp4

My change keeps the TS change and restores the previous behaviour.
