### PR TITLE
Proposal - changing structure.refreshed signal and logic

### DIFF
--- a/src/component/structure-component.ts
+++ b/src/component/structure-component.ts
@@ -165,6 +165,10 @@ class StructureComponent extends Component {
     //
 
     this.setDefaultAssembly(this.parameters.defaultAssembly)
+
+    this.structure.signals.refreshed.add(() => {
+      this.updateRepresentations({ position: true })
+    })
   }
 
   /**
@@ -288,10 +292,6 @@ class StructureComponent extends Component {
    */
   addTrajectory (trajPath = '', params: { [k: string]: any } = {}) {
     const traj = makeTrajectory(trajPath, this.structureView, params as TrajectoryParameters)
-
-    traj.signals.frameChanged.add(() => {
-      this.updateRepresentations({ 'position': true })
-    })
 
     const trajComp = new TrajectoryElement(this.stage, traj, params)
     this.trajList.push(trajComp)

--- a/src/structure/structure.ts
+++ b/src/structure/structure.ts
@@ -1059,9 +1059,15 @@ class Structure implements Structure{
     return chainnames.size
   }
 
-  //
-
-  updatePosition (position: Float32Array|number[]) {
+  /**
+   * Update atomic positions
+   * @param position - Array to copy positions from
+   * @param refresh - Whether or not to issue a full refresh (automatically
+   *                  triggers re-calculation of bounding boxes, spatial hash,
+   *                  representations etc etc). This provides compatibility with
+   *                  the old behaviour
+   */
+  updatePosition (position: Float32Array|number[], refresh: boolean = true) {
     let i = 0
 
     this.eachAtom(function (ap: AtomProxy) {
@@ -1069,13 +1075,21 @@ class Structure implements Structure{
       i += 3
     }, undefined)
 
-    this._hasCoords = undefined  // to trigger recalculation
+    this._hasCoords = undefined  // to trigger recalculation (of the _hasCoords value)
+
+    if (refresh) { 
+      this.refreshPosition()  // Recalculate bounds - structure-component listener will 
+                              // trigger representation rebuild
+    }
+
   }
 
   refreshPosition () {
     this.getBoundingBox(undefined, this.boundingBox)
     this.boundingBox.getCenter(this.center)
     this.spatialHash = new SpatialHash(this.atomStore, this.boundingBox)
+
+    this.signals.refreshed.dispatch(this)
   }
 
   /**

--- a/test/structure/tests-structure.spec.ts
+++ b/test/structure/tests-structure.spec.ts
@@ -4,22 +4,64 @@ import PdbParser from '../../src/parser/pdb-parser'
 
 
 import { join } from 'path'
-import * as fs from 'fs'
+// import * as fs from 'fs'
 
-describe('structure/structure', function () {
-  describe('iteration', function () {
-    it('polymer no chains', function () {
-      var file = join(__dirname, '/../data/BaceCgProteinAtomistic.pdb')
-      var str = fs.readFileSync(file, 'utf-8')
-      var streamer = new StringStreamer(str)
-      var pdbParser = new PdbParser(streamer)
-      return pdbParser.parse().then(function (structure) {
-        var i = 0
-        structure.eachPolymer(function () {
-          i += 1
-        })
-        expect(i).toBe(3)
+import { promises as fsp } from 'fs'
+import AtomProxy from '../../src/proxy/atom-proxy'
+
+async function loadExample() {
+  const file = join(__dirname, '/../data/BaceCgProteinAtomistic.pdb')
+  const str = await fsp.readFile(file, 'utf-8')
+  const streamer = new StringStreamer(str)
+  const pdbParser = new PdbParser(streamer)
+  const structure = await pdbParser.parse()
+  return structure
+}
+
+describe('structure/structure', () => {
+  describe('iteration', () => {
+    test('structure identifies multiple polymers without chain info', async () => {
+      expect.assertions(1)
+      const structure = await loadExample()
+      let i = 0
+      structure.eachPolymer( () => { i++ } )
+      expect(i).toBe(3)
+    })
+  })
+
+  describe('updatePosition', () => {
+    test('bounding box updates and signals', async () => {
+      expect.assertions(6)
+      let signalCount = 0
+      const structure = await loadExample()
+
+      structure.signals.refreshed.add(() => {
+        signalCount++
       })
+
+      const oldBoundingBox = structure.getBoundingBox()
+
+      const newCoords = new Float32Array(structure.atomCount * 3)
+      structure.eachAtom((ap: AtomProxy) => {
+        ap.positionToArray(newCoords, ap.index * 3)
+      })
+      newCoords.forEach((x, i) => {
+        newCoords[i] = x + 1
+      })
+
+      structure.updatePosition(newCoords, false) // false arg should prevent recalc of bounding box
+      
+      expect(signalCount).toEqual(0)
+      expect(oldBoundingBox.min.equals(structure.boundingBox.min)).toBeTruthy()
+      expect(oldBoundingBox.max.equals(structure.boundingBox.max)).toBeTruthy()
+
+      structure.updatePosition(newCoords, true) // signal should fire and boundingBox should udpate
+
+      expect(signalCount).toEqual(1)
+      expect(oldBoundingBox.min.equals(structure.boundingBox.min)).toBeFalsy()
+      expect(oldBoundingBox.max.equals(structure.boundingBox.max)).toBeFalsy()
     })
   })
 })
+
+


### PR DESCRIPTION
NGL supports updating atomic coordinates (there's an updatePosition method on structure, and the trajectory viewer works this way). Currently however, there's not really a consistent way to listen for coordinate changes. A `StructureComponent` can have a trajectory, and listens for `frameChanged` to updates representations.

This is problematic when you have multiple parts of your app that might update coordinates, but all of which need to know when coordinates change.

This PR assumes `Structure.updatePosition` is the public API for updating atomic coordinates. This method has a new `refresh` parameter (default true, set to false for old behaviour) which will call `Structure.refreshPosition`, this recalculates bounding boxes etc and fires the `refreshed` signal which triggers representation rebuilds and which other code (i.e. your application) can subscribe to. 

This also means StructureComponent doesn't need to listen for `frameChanged` on trajectory any more.


The main problem I can foresee if developers are already doing something clever calling updatePosition and then manually choosing what gets updated - in this case passing in `false` as the second argument will restore old behaviour

```typescript
const structure = stage.compList[0].structure
newCoords: number[] = calcNewCoords(structure)
structure.udpatePositions(newCoords, true) // All representations updated automatically
```


```typescript
const structure = stage.compList[0].structure
newCoords: number[] = calcNewCoords(structure)
structure.udpatePositions(newCoords, false) 
// Manually choose which repr to rebuild etc.
```

Comments etc very welcome!
