### PR TITLE
Make atom names unique only within a model for SDF

### DIFF
--- a/src/parser/sdf-parser.ts
+++ b/src/parser/sdf-parser.ts
@@ -102,7 +102,7 @@ class SdfParser extends StructureParser {
           }
 
           const element = line.substr(31, 3).trim()
-          const atomname = element + (idx + 1)
+          const atomname = element + (idx - modelAtomIdxStart + 1)
 
           atomStore.growIfFull()
           atomStore.atomTypeId[ idx ] = atomMap.add(atomname, element)


### PR DESCRIPTION
The atomTypeId array in AtomStore is currently an array of 16 unsigned integers. This causes problems when loading an SDF file with more than 64k atoms. The atomTypeId overflows at this point and the bonds begin to refer to the wrong atoms. For example a bond between atom 65535 and atom 65537 will turn into a bond between atom 65535 and atom 1.