### PR TITLE
Ts declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 build/
 node_modules/
-declarations/
 
 npm-debug.log
 

--- a/src/buffer/buffer.ts
+++ b/src/buffer/buffer.ts
@@ -17,7 +17,7 @@ import {
 
 import { Log } from '../globals'
 import { createParams, getTypedArray, getUintArray } from '../utils'
-import { NumberArray } from '../types'
+import { GenericColor, NumberArray } from '../types'
 import { getShader, ShaderDefines } from '../shader/shader-utils'
 import { serialArray } from '../math/array-utils'
 import { Picker } from '../utils/picker'
@@ -79,7 +79,7 @@ export const BufferDefaultParameters = {
   sortParticles: false,
   background: false
 }
-export type BufferParameters = typeof BufferDefaultParameters
+export type BufferParameters = Omit<typeof BufferDefaultParameters, 'diffuse'|'interiorColor'> & { diffuse: GenericColor; interiorColor: GenericColor }
 
 export const BufferParameterTypes = {
   opaqueBack: { updateShader: true },

--- a/src/buffer/cylinder-buffer.ts
+++ b/src/buffer/cylinder-buffer.ts
@@ -7,8 +7,8 @@
 // @ts-ignore: unused import required for declaration only
 import { Vector3, Matrix4 } from 'three'
 import { BufferRegistry, ExtensionFragDepth } from '../globals'
-import CylinderGeometryBuffer, { CylinderGeometryBufferDefaultParameters } from './cylindergeometry-buffer'
-import CylinderImpostorBuffer, { CylinderImpostorBufferDefaultParameters } from './cylinderimpostor-buffer'
+import CylinderGeometryBuffer, { CylinderGeometryBufferDefaultParameters, CylinderGeometryBufferParameters } from './cylindergeometry-buffer'
+import CylinderImpostorBuffer, { CylinderImpostorBufferDefaultParameters, CylinderImpostorBufferParameters } from './cylinderimpostor-buffer'
 import { BufferData } from './buffer'
 
 export interface CylinderBufferData extends BufferData {
@@ -21,7 +21,7 @@ export interface CylinderBufferData extends BufferData {
 export const CylinderBufferDefaultParameters = Object.assign({
   disableImpostor: false
 }, CylinderGeometryBufferDefaultParameters, CylinderImpostorBufferDefaultParameters)
-export type CylinderBufferParameters = typeof CylinderBufferDefaultParameters
+export type CylinderBufferParameters = (CylinderGeometryBufferParameters & {disableImpostor: boolean}) | (CylinderImpostorBufferParameters & {disableImpostor: boolean})
 
 /**
  * Cylinder buffer. Depending on the value {@link ExtensionFragDepth} and

--- a/src/buffer/cylindergeometry-buffer.ts
+++ b/src/buffer/cylindergeometry-buffer.ts
@@ -10,7 +10,7 @@ import { defaults } from '../utils'
 import { calculateCenterArray, serialBlockArray } from '../math/array-utils'
 import GeometryBuffer from './geometry-buffer'
 import { CylinderBufferData } from './cylinder-buffer'
-import { BufferDefaultParameters } from './buffer'
+import { BufferDefaultParameters, BufferParameters } from './buffer'
 
 const scale = new Vector3()
 const eye = new Vector3()
@@ -21,7 +21,7 @@ export const CylinderGeometryBufferDefaultParameters = Object.assign({
   radialSegments: 1,
   openEnded: true
 }, BufferDefaultParameters)
-export type CylinderGeometryBufferParameters = typeof CylinderGeometryBufferDefaultParameters
+export type CylinderGeometryBufferParameters = BufferParameters & {radialSegments: number, openEnded: boolean}
 
 function getData (data: CylinderBufferData, params: Partial<CylinderGeometryBufferParameters> = {}) {
   const geo = getGeo(params)

--- a/src/buffer/cylinderimpostor-buffer.ts
+++ b/src/buffer/cylinderimpostor-buffer.ts
@@ -11,13 +11,13 @@ import '../shader/CylinderImpostor.vert'
 import '../shader/CylinderImpostor.frag'
 
 import MappedAlignedBoxBuffer from './mappedalignedbox-buffer'
-import { BufferDefaultParameters, BufferParameterTypes, BufferTypes } from './buffer'
+import { BufferDefaultParameters, BufferParameters, BufferParameterTypes, BufferTypes } from './buffer'
 import { CylinderBufferData } from './cylinder-buffer'
 
 export const CylinderImpostorBufferDefaultParameters = Object.assign({
   openEnded: false
 }, BufferDefaultParameters)
-export type CylinderImpostorBufferParameters = typeof CylinderImpostorBufferDefaultParameters
+export type CylinderImpostorBufferParameters = BufferParameters & { openEnded: boolean }
 
 const CylinderImpostorBufferParameterTypes = Object.assign({
   openEnded: { updateShader: true }

--- a/src/buffer/hyperballstick-buffer.ts
+++ b/src/buffer/hyperballstick-buffer.ts
@@ -8,8 +8,8 @@
 import { Vector3, Matrix4 } from 'three'
 import { ExtensionFragDepth } from '../globals'
 import { calculateMinArray } from '../math/array-utils'
-import CylinderGeometryBuffer, { CylinderGeometryBufferDefaultParameters } from './cylindergeometry-buffer'
-import HyperballStickImpostorBuffer, { HyperballStickImpostorBufferDefaultParameters } from './hyperballstickimpostor-buffer'
+import CylinderGeometryBuffer, { CylinderGeometryBufferDefaultParameters, CylinderGeometryBufferParameters } from './cylindergeometry-buffer'
+import HyperballStickImpostorBuffer, { HyperballStickImpostorBufferDefaultParameters, HyperballStickImpostorBufferParameters } from './hyperballstickimpostor-buffer'
 import { BufferData } from './buffer'
 
 export interface HyperballStickBufferData extends BufferData {
@@ -23,7 +23,7 @@ export interface HyperballStickBufferData extends BufferData {
 export const HyperballStickBufferDefaultParameters = Object.assign({
   disableImpostor: false
 }, CylinderGeometryBufferDefaultParameters, HyperballStickImpostorBufferDefaultParameters)
-export type HyperballStickBufferParameters = typeof HyperballStickBufferDefaultParameters
+export type HyperballStickBufferParameters = HyperballStickImpostorBufferParameters & CylinderGeometryBufferParameters & { disableImpostor: boolean }
 
 /**
  * Hyperball stick buffer. Depending on the value {@link ExtensionFragDepth} and

--- a/src/buffer/hyperballstickimpostor-buffer.ts
+++ b/src/buffer/hyperballstickimpostor-buffer.ts
@@ -11,7 +11,7 @@ import '../shader/HyperballStickImpostor.vert'
 import '../shader/HyperballStickImpostor.frag'
 
 import MappedBoxBuffer from './mappedbox-buffer'
-import { BufferDefaultParameters, BufferParameterTypes, BufferData } from './buffer'
+import { BufferDefaultParameters, BufferParameterTypes, BufferData, BufferParameters } from './buffer'
 
 export interface HyperballStickImpostorBufferData extends BufferData {
   position1: Float32Array
@@ -24,7 +24,7 @@ export interface HyperballStickImpostorBufferData extends BufferData {
 export const HyperballStickImpostorBufferDefaultParameters = Object.assign({
   shrink: 0.14
 }, BufferDefaultParameters)
-export type HyperballStickImpostorBufferParameters = typeof HyperballStickImpostorBufferDefaultParameters
+export type HyperballStickImpostorBufferParameters = BufferParameters & { shrink: number }
 
 const HyperballStickImpostorBufferParameterTypes = Object.assign({
   shrink: { uniform: true }

--- a/src/buffer/point-buffer.ts
+++ b/src/buffer/point-buffer.ts
@@ -13,7 +13,7 @@ import '../shader/Point.frag'
 import { BufferRegistry } from '../globals'
 import { defaults } from '../utils'
 import { smoothstep } from '../math/math-utils'
-import Buffer, { BufferDefaultParameters, BufferParameterTypes, BufferData, BufferTypes } from './buffer'
+import Buffer, { BufferDefaultParameters, BufferParameterTypes, BufferData, BufferTypes, BufferParameters } from './buffer'
 
 function distance (x0: number, y0: number, x1: number, y1: number) {
   const dx = x1 - x0
@@ -70,7 +70,15 @@ export const PointBufferDefaultParameters = Object.assign({
   forceTransparent: false,
   edgeBleach: 0.0
 }, BufferDefaultParameters)
-export type PointBufferParameters = typeof PointBufferDefaultParameters
+export type PointBufferParameters = BufferParameters & {
+  pointSize: number,
+  sizeAttenuation: boolean,
+  sortParticles: boolean,
+  alphaTest: number,
+  useTexture: boolean,
+  forceTransparent: boolean,
+  edgeBleach: number
+}
 
 const PointBufferParameterTypes = Object.assign({
   pointSize: { uniform: 'size' },

--- a/src/buffer/sphere-buffer.ts
+++ b/src/buffer/sphere-buffer.ts
@@ -7,7 +7,7 @@
 // @ts-ignore: unused import Vector3, Matrix4 required for declaration only 
 import { Vector3, Matrix4 } from 'three'
 import { BufferRegistry, ExtensionFragDepth } from '../globals'
-import SphereGeometryBuffer, { SphereGeometryBufferDefaultParameters } from './spheregeometry-buffer'
+import SphereGeometryBuffer, { SphereGeometryBufferDefaultParameters, SphereGeometryBufferParameters } from './spheregeometry-buffer'
 import SphereImpostorBuffer from './sphereimpostor-buffer'
 import { BufferData } from './buffer'
 
@@ -18,7 +18,7 @@ export interface SphereBufferData extends BufferData {
 export const SphereBufferDefaultParameters = Object.assign({
   disableImpostor: false
 }, SphereGeometryBufferDefaultParameters)
-export type SphereBufferParameters = typeof SphereBufferDefaultParameters
+export type SphereBufferParameters = SphereGeometryBufferParameters & { disableImpostor: boolean }
 
 /**
  * Sphere buffer. Depending on the value {@link ExtensionFragDepth} and

--- a/src/buffer/spheregeometry-buffer.ts
+++ b/src/buffer/spheregeometry-buffer.ts
@@ -8,14 +8,14 @@ import { IcosahedronBufferGeometry, Vector3, Matrix4 } from 'three'
 import { defaults } from '../utils'
 import GeometryBuffer from './geometry-buffer'
 import { SphereBufferData } from './sphere-buffer'
-import { BufferDefaultParameters } from './buffer'
+import { BufferDefaultParameters, BufferParameters } from './buffer'
 
 const scale = new Vector3()
 
 export const SphereGeometryBufferDefaultParameters = Object.assign({
   sphereDetail: 1
 }, BufferDefaultParameters)
-export type SphereGeometryBufferParameters = typeof SphereGeometryBufferDefaultParameters
+export type SphereGeometryBufferParameters = BufferParameters & { sphereDetail: number }
 
 /**
  * Sphere geometry buffer.

--- a/src/buffer/text-buffer.ts
+++ b/src/buffer/text-buffer.ts
@@ -15,7 +15,8 @@ import { createParams } from '../utils'
 import MappedQuadBuffer from './mappedquad-buffer'
 import { IgnorePicker } from '../utils/picker'
 import { edt } from '../utils/edt'
-import { BufferDefaultParameters, BufferParameterTypes, BufferData, BufferTypes } from './buffer'
+import { BufferDefaultParameters, BufferParameterTypes, BufferData, BufferTypes, BufferParameters } from './buffer'
+import { GenericColor } from '../types'
 
 const TextAtlasCache: { [k: string]: TextAtlas } = {}
 
@@ -305,7 +306,25 @@ export const TextBufferDefaultParameters = Object.assign({
   forceTransparent: true,
   fixedSize: false
 }, BufferDefaultParameters)
-export type TextBufferParameters = typeof TextBufferDefaultParameters
+export type TextBufferParameters = BufferParameters & {
+  fontFamily: TextFonts,
+  fontStyle: TextStyles,
+  fontWeight: TextWeights,
+  fontSize: number,
+  xOffset: number,
+  yOffset: number,
+  zOffset: number,
+  attachment: TextAttachments,
+  showBorder: boolean,
+  borderColor: GenericColor,
+  borderWidth: number,
+  showBackground: boolean,
+  backgroundColor: GenericColor,
+  backgroundMargin: number,
+  backgroundOpacity: number,
+  forceTransparent: boolean,
+  fixedSize: boolean
+}
 
 const TextBufferParameterTypes = Object.assign({
   fontFamily: { uniform: true },

--- a/src/buffer/tubemesh-buffer.ts
+++ b/src/buffer/tubemesh-buffer.ts
@@ -10,7 +10,7 @@ import { Vector3, Matrix4 } from 'three'
 import { defaults, getUintArray } from '../utils'
 import { serialArray } from '../math/array-utils'
 import MeshBuffer from './mesh-buffer'
-import { BufferDefaultParameters, BufferData } from './buffer'
+import { BufferDefaultParameters, BufferData, BufferParameters } from './buffer'
 import {Log} from "../globals";
 
 const vTangent = new Vector3()
@@ -27,7 +27,11 @@ export const TubeMeshBufferDefaultParameters = Object.assign({
   capped: false,
   aspectRatio: 1.0
 }, BufferDefaultParameters)
-export type TubeMeshBufferParameters = typeof TubeMeshBufferDefaultParameters
+export type TubeMeshBufferParameters = BufferParameters & {
+  radialSegments: number,
+  capped: boolean,
+  aspectRatio: number
+}
 
 function getData (data: TubeMeshBufferData, params: Partial<TubeMeshBufferParameters> = {}) {
   const radialSegments = defaults(params.radialSegments, 4)

--- a/src/buffer/vector-buffer.ts
+++ b/src/buffer/vector-buffer.ts
@@ -11,7 +11,8 @@ import '../shader/Line.vert'
 import '../shader/Line.frag'
 
 import { uniformArray3 } from '../math/array-utils'
-import Buffer, { BufferDefaultParameters, BufferData } from './buffer'
+import Buffer, { BufferDefaultParameters, BufferData, BufferParameters } from './buffer'
+import { GenericColor } from '../types'
 
 function getSize(data: BufferData){
   const n = data.position!.length / 3
@@ -26,7 +27,7 @@ export const VectorBufferDefaultParameters = Object.assign({
   scale: 1,
   color: 'grey'
 }, BufferDefaultParameters)
-export type VectorBufferParameters = typeof VectorBufferDefaultParameters
+export type VectorBufferParameters = BufferParameters & { scale: number, color: GenericColor }
 
 /**
  * Vector buffer. Draws vectors as lines.

--- a/src/buffer/wideline-buffer.ts
+++ b/src/buffer/wideline-buffer.ts
@@ -12,7 +12,7 @@ import '../shader/WideLine.frag'
 
 import { BufferRegistry } from '../globals'
 import MappedQuadBuffer from './mappedquad-buffer'
-import { BufferDefaultParameters, BufferParameterTypes, BufferData } from './buffer'
+import { BufferDefaultParameters, BufferParameterTypes, BufferData, BufferParameters } from './buffer'
 
 export interface WideLineBufferData extends BufferData {
   position1: Float32Array
@@ -23,7 +23,7 @@ export interface WideLineBufferData extends BufferData {
 export const WideLineBufferDefaultParameters = Object.assign({
   linewidth: 2
 }, BufferDefaultParameters)
-export type WideLineBufferParameters = typeof WideLineBufferDefaultParameters
+export type WideLineBufferParameters = BufferParameters & { linewidth: number }
 
 const WideLineBufferParameterTypes = Object.assign({
   linewidth: { uniform: true }

--- a/src/color/colormaker.ts
+++ b/src/color/colormaker.ts
@@ -8,7 +8,7 @@ import { Vector3, Color } from 'three'
 import * as chroma from 'chroma-js'
 
 import { createParams } from '../utils'
-import { NumberArray, Partial } from '../types'
+import { NumberArray } from '../types'
 import Structure from '../structure/structure'
 import Surface from '../surface/surface'
 import Volume from '../surface/volume'

--- a/src/component/representation-collection.ts
+++ b/src/component/representation-collection.ts
@@ -4,10 +4,9 @@
  * @private
  */
 
-import { Color } from 'three'
-
 import RepresentationElement from './representation-element'
 import Collection from './collection'
+import { GenericColor } from '../types'
 
 class RepresentationCollection extends Collection<RepresentationElement> {
   setParameters (params: any) {
@@ -22,7 +21,7 @@ class RepresentationCollection extends Collection<RepresentationElement> {
     return this.forEach((repr) => repr.setSelection(string))
   }
 
-  setColor (color: number|string|Color) {
+  setColor (color: GenericColor) {
     return this.forEach((repr) => repr.setColor(color))
   }
 

--- a/src/component/structure-component.ts
+++ b/src/component/structure-component.ts
@@ -328,7 +328,6 @@ class StructureComponent extends Component {
    * @param  {Integer} [duration] - duration of the animation, defaults to 0
    * @return {undefined}
    */
-  autoView (duration?: number): any
   autoView (sele?: string|number, duration?: number) {
     if (typeof sele === 'number') {
       duration = sele

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -105,11 +105,11 @@ export const BufferRegistry = new Registry('buffer')
 export const PickerRegistry = new Registry('picker')
 
 export let ListingDatasource: any
-export function setListingDatasource (value: boolean) {
+export function setListingDatasource (value: any) {
   ListingDatasource = value
 }
 
-export let TrajectoryDatasource: any
-export function setTrajectoryDatasource (value: boolean) {
+export let TrajectoryDatasource: any  // TODO should accept mdsrvDatasource
+export function setTrajectoryDatasource (value: any) {
   TrajectoryDatasource = value
 }

--- a/src/loader/loader-utils.ts
+++ b/src/loader/loader-utils.ts
@@ -7,7 +7,6 @@
 import {
   DatasourceRegistry, DecompressorRegistry, ParserRegistry, ScriptExtensions
 } from '../globals'
-import { Partial } from '../types'
 import ParserLoader from './parser-loader'
 import ScriptLoader from './script-loader'
 

--- a/src/loader/loader-utils.ts
+++ b/src/loader/loader-utils.ts
@@ -7,7 +7,7 @@
 import {
   DatasourceRegistry, DecompressorRegistry, ParserRegistry, ScriptExtensions
 } from '../globals'
-import ParserLoader from './parser-loader'
+import ParserLoader, { ParserParams } from './parser-loader'
 import ScriptLoader from './script-loader'
 
 export interface LoaderParameters {
@@ -105,7 +105,7 @@ export function getDataInfo (src: LoaderInput) {
  * @param  {LoaderParameters} params - loading parameters
  * @return {Promise} Promise resolves to the loaded data
  */
-export function autoLoad (file: LoaderInput, params: Partial<LoaderParameters> = {}) {
+export function autoLoad (file: LoaderInput, params: Partial<LoaderParameters & ParserParams> = {}) {
   const p = Object.assign(getDataInfo(file), params)
 
   let loader

--- a/src/loader/loader.ts
+++ b/src/loader/loader.ts
@@ -6,7 +6,6 @@
 
 import { ParserRegistry } from '../globals'
 import { createParams } from '../utils'
-import { Partial } from '../types'
 import FileStreamer from '../streamer/file-streamer'
 import NetworkStreamer from '../streamer/network-streamer'
 import { LoaderParameters, LoaderInput } from './loader-utils'

--- a/src/representation/label-representation.ts
+++ b/src/representation/label-representation.ts
@@ -14,6 +14,7 @@ import { RepresentationParameters } from './representation';
 import { Structure } from '../ngl';
 import Viewer from '../viewer/viewer';
 import StructureView from '../structure/structure-view';
+import { GenericColor } from '../types'
 
 export interface TextDataField {
   position?: boolean
@@ -74,10 +75,10 @@ export interface LabelRepresentationParameters extends RepresentationParameters 
   zOffset: number
   attachment: 'bottom-left'|'bottom-center'|'bottom-right'|'middle-left'|'middle-center'|'middle-right'|'top-left'|'top-center'|'top-right'
   showBorder: boolean
-  borderColor: number
+  borderColor: GenericColor
   borderWidth: number
   showBackground: boolean
-  backgroundColor: number
+  backgroundColor: GenericColor
   backgroundMargin: number
   backgroundOpacity: number
   fixedSize: boolean
@@ -99,10 +100,10 @@ class LabelRepresentation extends StructureRepresentation {
   protected zOffset: number
   protected attachment: 'bottom-left'|'bottom-center'|'bottom-right'|'middle-left'|'middle-center'|'middle-right'|'top-left'|'top-center'|'top-right'
   protected showBorder: boolean
-  protected borderColor: number
+  protected borderColor: GenericColor
   protected borderWidth: number
   protected showBackground: boolean
-  protected backgroundColor: number
+  protected backgroundColor: GenericColor
   protected backgroundMargin: number
   protected backgroundOpacity: number
   protected fixedSize: boolean

--- a/src/representation/label-representation.ts
+++ b/src/representation/label-representation.ts
@@ -39,7 +39,7 @@ export interface TextDataField {
  *                                 `labelText` list is used.
  * @property {String[]} labelText - list of label strings, must set `labelType` to "text"
  *                                   to take effect
- * @property {String[]} labelFormat - sprintf-js format string, any attribute of
+ * @property {String} labelFormat - sprintf-js format string, any attribute of
  *                                  {@link  AtomProxy} can be used
  * @property {String} labelGrouping - grouping of the label, one of:
  *                                 "atom", "residue".
@@ -64,7 +64,7 @@ export interface TextDataField {
  */
 export interface LabelRepresentationParameters extends RepresentationParameters {
   labelType: LabelType
-  labelText: string
+  labelText: string[]
   labelFormat: string
   labelGrouping: 'atom'|'residue'
   fontFamily: 'sans-serif'|'monospace'|'serif'
@@ -89,7 +89,7 @@ export interface LabelRepresentationParameters extends RepresentationParameters 
 class LabelRepresentation extends StructureRepresentation {
 
   protected labelType: LabelType
-  protected labelText: string
+  protected labelText: string[]
   protected labelFormat: string
   protected labelGrouping: 'atom'|'residue'
   protected fontFamily: 'sans-serif'|'monospace'|'serif'

--- a/src/representation/measurement-representation.ts
+++ b/src/representation/measurement-representation.ts
@@ -17,6 +17,7 @@ import Viewer from '../viewer/viewer';
 import StructureView from '../structure/structure-view';
 import { LabelRepresentationParameters } from './label-representation';
 import TextBuffer, { TextBufferData } from '../buffer/text-buffer';
+import { GenericColor } from '../types'
 
 export interface LabelDataField {
   position?: boolean
@@ -40,7 +41,7 @@ export interface LabelDataField {
 export interface MeasurementRepresentationParameters extends StructureRepresentationParameters {
   labelVisible: boolean
   labelSize: number
-  labelColor: number
+  labelColor: GenericColor
   labelType: 'atomname'|'atomindex'|'occupancy'|'bfactor'|'serial'|'element'|'atom'|'resname'|'resno'|'res'|'text'|'qualified'
   labelText: string
   labelFormat: string
@@ -54,10 +55,10 @@ export interface MeasurementRepresentationParameters extends StructureRepresenta
   labelZOffset: number
   labelAttachment: 'bottom-left'|'bottom-center'|'bottom-right'|'middle-left'|'middle-center'|'middle-right'|'top-left'|'top-center'|'top-right'
   labelBorder: boolean
-  labelBorderColor: number
+  labelBorderColor: GenericColor
   labelBorderWidth: number
   labelBackground: boolean
-  labelBackgroundColor: number
+  labelBackgroundColor: GenericColor
   labelBackgroundMargin: number
   labelBackgroundOpacity: number
   labelFixedSize: boolean
@@ -73,7 +74,7 @@ abstract class MeasurementRepresentation extends StructureRepresentation {
   protected n: number
   protected labelVisible: boolean
   protected labelSize: number
-  protected labelColor: number
+  protected labelColor: GenericColor
   protected labelType: 'atomname'|'atomindex'|'occupancy'|'bfactor'|'serial'|'element'|'atom'|'resname'|'resno'|'res'|'text'|'qualified'
   protected labelText: string
   protected labelFormat: string
@@ -87,10 +88,10 @@ abstract class MeasurementRepresentation extends StructureRepresentation {
   protected labelZOffset: number
   protected labelAttachment: 'bottom-left'|'bottom-center'|'bottom-right'|'middle-left'|'middle-center'|'middle-right'|'top-left'|'top-center'|'top-right'
   protected labelBorder: boolean
-  protected labelBorderColor: number
+  protected labelBorderColor: GenericColor
   protected labelBorderWidth: number
   protected labelBackground: boolean
-  protected labelBackgroundColor: number
+  protected labelBackgroundColor: GenericColor
   protected labelBackgroundMargin: number
   protected labelBackgroundOpacity: number
   protected labelFixedSize: boolean

--- a/src/representation/representation.ts
+++ b/src/representation/representation.ts
@@ -13,6 +13,7 @@ import Counter from '../utils/counter'
 import Viewer from '../viewer/viewer'
 import { BufferParameters, BufferSide, default as Buffer } from '../buffer/buffer';
 import { ColorData, ColormakerParameters, ColorMode } from '../color/colormaker';
+import { GenericColor } from '../types'
 
 export interface RepresentationParameters {
   name: string
@@ -29,22 +30,22 @@ export interface RepresentationParameters {
   colorScheme: string,
   colorScale: string | number[],
   colorReverse: boolean,
-  colorValue: number,
+  colorValue: GenericColor,
   colorDomain: number[],
   colorMode: ColorMode,
   colorSpace: 'sRGB' | 'linear',
   roughness: number,
   metalness: number,
-  diffuse: Color,
+  diffuse: GenericColor,
   diffuseInterior: boolean,
   useInteriorColor: boolean,
-  interiorColor: Color,
+  interiorColor: GenericColor,
   interiorDarkening: number,
   disablePicking: boolean,
   matrix: Matrix4
   quality: string,
   visible: boolean,
-  color: number | string | Color,
+  color: GenericColor,
   sphereDetail: number,
   radialSegments: number,
   openEnded: boolean
@@ -122,10 +123,10 @@ class Representation {
   protected colorMode: ColorMode
   protected roughness: number
   protected metalness: number
-  protected diffuse: number
+  protected diffuse: GenericColor
   protected diffuseInterior?: boolean
   protected useInteriorColor?: boolean
-  protected interiorColor: number
+  protected interiorColor: GenericColor
   protected interiorDarkening: number
   protected disablePicking: boolean
   protected sphereDetail: number

--- a/src/stage/stage.ts
+++ b/src/stage/stage.ts
@@ -37,6 +37,7 @@ import VolumeComponent from '../component/volume-component'
 import ComponentCollection from '../component/component-collection'
 import RepresentationCollection from '../component/representation-collection'
 import { autoLoad, getFileInfo, LoaderParameters } from '../loader/loader-utils'
+import { ParserParams } from '../loader/parser-loader'
 import AtomProxy from '../proxy/atom-proxy'
 import Animation from '../animation/animation'
 import Selection from '../selection/selection'
@@ -449,7 +450,7 @@ class Stage {
    *                   a {@link SurfaceComponent} or a {@link ScriptComponent} object,
    *                   depending on the type of the loaded file.
    */
-  loadFile (path: string|File|Blob, params: Partial<StageLoadFileParams> = {}) {
+  loadFile (path: string|File|Blob, params: Partial<StageLoadFileParams & ParserParams> = {}) {
     const p = Object.assign({}, this.defaultFileParams, params)
     const name = getFileInfo(path).name
 

--- a/src/structure/structure.ts
+++ b/src/structure/structure.ts
@@ -433,7 +433,7 @@ class Structure implements Structure{
    * @param  {Selection} selection - the selection object
    * @return {BitArray} set of atoms
    */
-  getAtomSetWithinGroup (selection: boolean|Selection) {
+  getAtomSetWithinGroup (selection: boolean|Selection|BitArray) {
     const atomResidueIndex = this.atomStore.residueIndex
     const atomSet = this.getAtomSet(false)
     const rp = this.getResidueProxy()

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,5 +5,3 @@ export type TypedArray = (
 )
 
 export type NumberArray = number[] | TypedArray
-
-export type Partial<T> = { [p in keyof T]?: T[p] }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { Color } from "./ngl"
+
 export type TypedArray = (
   Int8Array | Int16Array | Int32Array |
   Uint8ClampedArray | Uint8Array | Uint16Array | Uint32Array |
@@ -5,3 +7,5 @@ export type TypedArray = (
 )
 
 export type NumberArray = number[] | TypedArray
+
+export type GenericColor = number|string|Color


### PR DESCRIPTION
This PR contains a new round about Typescript declarations.

1. Currently declarations are not shipped via npm: the user still has to make the compilation locally to get the files. This is due to a line in git ignore which prevents committing the declaration folder located in ./dist/
2. Various improvements to declarations, mainly function parameters which had been wrongly typed previously. This collection of fixes comes from unwarranted typescript errors that were raised in a project I am working on. Notably: `color` parameter can be a string (was limited to numbers), `autoview()` can take a selection string as a parameter, `labelText` takes an array of strings,...