### PR TITLE
Fix parm7 parsing: guessElement for CL1 returns carbon

### DIFF
--- a/src/structure/structure-utils.ts
+++ b/src/structure/structure-utils.ts
@@ -899,11 +899,18 @@ const elm1 = [ 'H', 'C', 'O', 'N', 'S', 'P' ]
 const elm2 = [ 'NA', 'CL', 'FE' ]
 
 export function guessElement (atomName: string) {
-  let at = atomName.trim().toUpperCase()
-  // parseInt('C') -> NaN; (NaN > -1) -> false
-  if (parseInt(at.charAt(0)) > -1) at = at.substr(1)
-    // parse again to check for a second integer
-  if (parseInt(at.charAt(0)) > -1) at = at.substr(1)
+  // Retain first group of letters in atomName
+  let at = atomName.toUpperCase()
+  let begin = 0, end = 0
+  for (let i = 0; i < at.length ; i++) {
+    if (at.charCodeAt(i) < 65) {
+      if (end > 0) break
+      ++begin
+    }
+    else end = i + 1
+  }
+  if (begin > 0 || end < at.length) at = at.substring(begin, end)
+  
   const n = at.length
 
   if (n === 0) return ''

--- a/src/structure/structure-utils.ts
+++ b/src/structure/structure-utils.ts
@@ -17,7 +17,7 @@ import StructureBuilder from '../structure/structure-builder'
 import Polymer from '../proxy/polymer'
 import ResidueProxy from '../proxy/residue-proxy'
 
-import { UnknownBackboneType, AA3, Bases } from './structure-constants'
+import { UnknownBackboneType, AA3, Bases, AtomicNumbers } from './structure-constants'
 
 export function reorderAtoms (structure: Structure) {
   if (Debug) Log.time('reorderAtoms')
@@ -918,6 +918,7 @@ export function guessElement (atomName: string) {
   if (n === 2) {
     if (elm2.indexOf(at) !== -1) return at
     if (elm1.indexOf(at[0]) !== -1) return at[0]
+    if (at in AtomicNumbers) return at
   }
   if (n >= 3) {
     if (elm1.indexOf(at[0]) !== -1) return at[0]

--- a/test/structure/tests-structure-utils.spec.ts
+++ b/test/structure/tests-structure-utils.spec.ts
@@ -1,0 +1,24 @@
+import { guessElement } from '../../src/structure/structure-utils'
+
+
+describe('structure-utils/guessElement', function () {
+  describe('basic', function () {
+    it('strips numbers in atom names', function () {
+        expect(guessElement('CL1')).toBe('CL')
+        expect(guessElement('10CB')).toBe('C')
+    })
+
+    it('strips spaces and signs in atom names', function () {
+        expect(guessElement(' CL+1')).toBe('CL')
+    })
+
+    it('prioritizes Carbon over Calcium', function () {
+        expect(guessElement('CA')).toBe('C')
+    })
+
+    it('prioritizes first letter when element is not Na, Cl nor Fe in atomnames containing 2 letters ', function () {
+        expect(guessElement('HF')).toBe('H')
+    })
+    
+  })
+})

--- a/test/structure/tests-structure-utils.spec.ts
+++ b/test/structure/tests-structure-utils.spec.ts
@@ -19,6 +19,12 @@ describe('structure-utils/guessElement', function () {
     it('prioritizes first letter when element is not Na, Cl nor Fe in atomnames containing 2 letters ', function () {
         expect(guessElement('HF')).toBe('H')
     })
+
+    it('recognizes other standard elements names with 2 letters', function () {
+        expect(guessElement('MG')).toBe('MG')
+        expect(guessElement('MZ')).toBe('')
+        expect(guessElement('NE')).toBe('N') // 'N' has priority
+    })
     
   })
 })


### PR DESCRIPTION
A bug was visible after loading a parm7 (Amber topology file) file where a ligand contains a chlorine with an atom name like `CL1`.
When parsing parm7 files, NGL infers the element from the atom name using the `guessElement()` utility function.
In this function there was a limitation to atom name processing where digits were stripped from the left only, and up to 2 digits.
This PR contains a change to find the first group of letters in the atom name with minimal processing (no regexp, no `parseInt`, only one call to `.substring()` at most)
It also adds to the logic of element identification by recognizing 2-letters standard elements names such as `Mg`
It was impractical to share the parm7 file where the bug was detected but a series of tests has been added to assess the guessElement function specs.
