### PR TITLE
Infer bond options

### DIFF
--- a/src/loader/parser-loader.ts
+++ b/src/loader/parser-loader.ts
@@ -5,6 +5,7 @@
  */
 
 import { ParserRegistry } from '../globals'
+import type { InferBondsOptions } from '../structure/structure-utils'
 import Loader from './loader'
 import { LoaderParameters, LoaderInput } from './loader-utils'
 
@@ -18,6 +19,7 @@ export interface ParserParams {
   delimiter?: string
   comment?: string
   columnNames?: string
+  inferBonds?: InferBondsOptions
 }
 
 /**
@@ -37,6 +39,7 @@ class ParserLoader extends Loader {
       delimiter: params.delimiter,
       comment: params.comment,
       columnNames: params.columnNames,
+      inferBonds: params.inferBonds,
       name: this.parameters.name,
       path: this.parameters.path
     }

--- a/src/parser/cif-parser.ts
+++ b/src/parser/cif-parser.ts
@@ -983,7 +983,7 @@ class CifParser extends StructureParser {
               inscode = (inscode === '?') ? '' : inscode
               const chainname = ls[ authAsymId ]
               const chainid = ls[ labelAsymId ]
-              const hetero = (ls[ groupPDB ][ 0 ] === 'H') ? 1 : 0
+              const hetero = (ls[ groupPDB ][ 0 ] === 'H')
 
               //
 

--- a/src/parser/gro-parser.ts
+++ b/src/parser/gro-parser.ts
@@ -121,7 +121,7 @@ class GroParser extends StructureParser {
           atomStore.z[ idx ] = z
           atomStore.serial[ idx ] = serial
 
-          sb.addAtom(modelIdx, '', '', resname, resno, 0, 'l')
+          sb.addAtom(modelIdx, '', '', resname, resno, false, 'l')
 
           idx += 1
         }

--- a/src/parser/mol2-parser.ts
+++ b/src/parser/mol2-parser.ts
@@ -158,7 +158,7 @@ class Mol2Parser extends StructureParser {
           atomStore.serial[ idx ] = serial
           atomStore.partialCharge[ idx ] = partialCharge
 
-          sb.addAtom(modelIdx, '', '', resname, resno, 1)
+          sb.addAtom(modelIdx, '', '', resname, resno, true)
 
           idx += 1
         } else if (currentRecordType === bondRecordType) {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -7,7 +7,6 @@
 import { Debug, Log } from '../globals'
 import { defaults } from '../utils'
 import Streamer from '../streamer/streamer';
-import StructureBuilder from '../structure/structure-builder';
 
 export interface ParserParameters {
   name: string
@@ -18,7 +17,6 @@ class Parser {
   streamer: Streamer
   name: string
   path: string
-  structureBuilder: StructureBuilder
   [k: string]: any
   
   constructor (streamer: Streamer, params?: Partial<ParserParameters>) {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -7,6 +7,7 @@
 import { Debug, Log } from '../globals'
 import { defaults } from '../utils'
 import Streamer from '../streamer/streamer';
+import StructureBuilder from '../structure/structure-builder';
 
 export interface ParserParameters {
   name: string
@@ -17,6 +18,7 @@ class Parser {
   streamer: Streamer
   name: string
   path: string
+  structureBuilder: StructureBuilder
   [k: string]: any
   
   constructor (streamer: Streamer, params?: Partial<ParserParameters>) {

--- a/src/parser/pdb-parser.ts
+++ b/src/parser/pdb-parser.ts
@@ -139,7 +139,7 @@ class PdbParser extends StructureParser {
 
     let line, recordName
     let serial, chainname: string, resno: number, resname: string, occupancy: number
-    let inscode: string, atomname, hetero: number, bfactor: number, altloc
+    let inscode: string, atomname, hetero: boolean, bfactor: number, altloc
     let formalCharge: number
 
     let startChain, startResi, startIcode
@@ -275,7 +275,7 @@ class PdbParser extends StructureParser {
           if (isPqr) {
             serial = parseInt(ls![ 1 ])
             element = ''
-            hetero = (line[ 0 ] === 'H') ? 1 : 0
+            hetero = (line[ 0 ] === 'H')
             chainname = dd ? '' : ls![ 4 ]
             resno = parseInt(ls![ 5 - dd! ])
             inscode = ''
@@ -287,7 +287,7 @@ class PdbParser extends StructureParser {
             if (hex && serial === 99999) {
               serialRadix = 16
             }
-            hetero = (line[ 0 ] === 'H') ? 1 : 0
+            hetero = (line[ 0 ] === 'H')
             chainname = line[ 21 ].trim()
             resno = parseInt(line.substr(22, 4), resnoRadix)
             if (hex && resno === 9999) {

--- a/src/parser/pdb-parser.ts
+++ b/src/parser/pdb-parser.ts
@@ -14,7 +14,7 @@ import Unitcell, { UnitcellParams } from '../symmetry/unitcell'
 import Assembly, { AssemblyPart } from '../symmetry/assembly'
 import { PDBQTSpecialElements, WaterNames } from '../structure/structure-constants'
 import {
-  assignSecondaryStructure, buildUnitcellAssembly,
+  assignSecondaryStructure, InferBondsOptions, buildUnitcellAssembly,
   calculateBonds, calculateChainnames, calculateSecondaryStructure
 } from '../structure/structure-utils'
 import Streamer from '../streamer/streamer';
@@ -76,11 +76,17 @@ function getModresId (resno: number, chainname?: string, inscode?: string) {
   if (inscode) id += `^${inscode}`
   return id
 }
+
 export interface PdbParserParameters extends ParserParameters {
   hex: boolean
+  inferBonds: InferBondsOptions
 }
 
 class PdbParser extends StructureParser {
+
+  hex: boolean
+  inferBonds: InferBondsOptions
+
   /**
    * Create a pdb parser
    * @param  {Streamer} streamer - streamer object
@@ -88,6 +94,9 @@ class PdbParser extends StructureParser {
    * @param  {Boolean} params.hex - hexadecimal parsing of
    *                                atom numbers >99.999 and
    *                                residue numbers >9.999
+   * @param  {InferBondsOptions} params.inferBonds: 'all': use explicit bonds and detect by distance
+   *                                               'auto': If a residue has explicit bonds, don't auto-detect
+   *                                               'none': Don't add any bonds automatically
    * @return {undefined}
    */
   constructor (streamer: Streamer, params?: Partial<PdbParserParameters>) {
@@ -96,6 +105,7 @@ class PdbParser extends StructureParser {
     super(streamer, p)
 
     this.hex = defaults(p.hex, false)
+    this.inferBonds = defaults(p.inferBonds, 'auto')
   }
 
   get type () { return 'pdb' }
@@ -707,7 +717,7 @@ class PdbParser extends StructureParser {
 
     s.finalizeAtoms()
     if (!isLegacy) calculateChainnames(s)
-    calculateBonds(s)
+    calculateBonds(s, this.inferBonds)
     s.finalizeBonds()
 
     if (!helices.length && !sheets.length) {

--- a/src/parser/pdb-parser.ts
+++ b/src/parser/pdb-parser.ts
@@ -95,7 +95,7 @@ class PdbParser extends StructureParser {
    *                                atom numbers >99.999 and
    *                                residue numbers >9.999
    * @param  {InferBondsOptions} params.inferBonds: 'all': use explicit bonds and detect by distance
-   *                                               'auto': If a residue has explicit bonds, don't auto-detect
+   *                                               'auto': If a hetgroup residue has explicit bonds, don't auto-detect
    *                                               'none': Don't add any bonds automatically
    * @return {undefined}
    */
@@ -105,7 +105,7 @@ class PdbParser extends StructureParser {
     super(streamer, p)
 
     this.hex = defaults(p.hex, false)
-    this.inferBonds = defaults(p.inferBonds, 'auto')
+    this.inferBonds = defaults(p.inferBonds, 'all')
   }
 
   get type () { return 'pdb' }

--- a/src/parser/prmtop-parser.ts
+++ b/src/parser/prmtop-parser.ts
@@ -207,7 +207,7 @@ class PrmtopParser extends StructureParser {
       }
       atomStore.atomTypeId[i] = atomMap.add(atomNames![i])
       atomStore.serial[i] = i + 1
-      sb.addAtom(0, '', '', curResname, curResno)
+      sb.addAtom(0, '', '', curResname, curResno, false)
     }
 
     atomStore.partialCharge.set(charges!)

--- a/src/parser/psf-parser.ts
+++ b/src/parser/psf-parser.ts
@@ -78,7 +78,7 @@ class PsfParser extends StructureParser {
           atomStore.serial[ idx ] = serial
           atomStore.partialCharge[ idx ] = charge
 
-          sb.addAtom(0, chainid, chainid, resname, resno)
+          sb.addAtom(0, chainid, chainid, resname, resno, false)
 
           idx += 1
           lastSegid = segid

--- a/src/parser/sdf-parser.ts
+++ b/src/parser/sdf-parser.ts
@@ -180,7 +180,7 @@ class SdfParser extends StructureParser {
           atomStore.serial[ idx ] = isV3000 ? atomindex : idx
           atomStore.formalCharge[ idx ] = charge
 
-          sb.addAtom(modelIdx, '', '', 'HET', 1, 1)
+          sb.addAtom(modelIdx, '', '', 'HET', 1, true)
 
           idx += 1
         } else if (

--- a/src/parser/structure-parser.ts
+++ b/src/parser/structure-parser.ts
@@ -16,6 +16,9 @@ export interface StructureParserParameters extends ParserParameters {
   cAlphaOnly: boolean
 }
 class StructureParser extends Parser {
+
+  structureBuilder: StructureBuilder
+
   constructor (streamer: Streamer, params?: Partial<StructureParserParameters>) {
     var p = params || {}
 

--- a/src/parser/top-parser.ts
+++ b/src/parser/top-parser.ts
@@ -159,7 +159,7 @@ class TopParser extends StructureParser {
           atomStore.atomTypeId[atomIdx] = atomMap.add(atomname)
           atomStore.serial[atomIdx] = atomIdx + 1
           atomStore.partialCharge[atomIdx] = charge
-          sb.addAtom(0, chainname, chainid, resname, resIdx + 1)
+          sb.addAtom(0, chainname, chainid, resname, resIdx + 1, false)
           ++atomIdx
           lastResno = resno
         })

--- a/src/structure/structure-utils.ts
+++ b/src/structure/structure-utils.ts
@@ -513,7 +513,7 @@ export function calculateBonds (structure: Structure, inferBonds: InferBondsOpti
 
 /**
  * Should Bonds be inferred for `all` atoms, `none` or `auto`
- * If `auto`, any residue with at least one CONECT record will 
+ * If `auto`, any hetgroup residue with at least one CONECT record will 
  * not have bonding inferred, and will rely on the CONECT records
  */
 export type InferBondsOptions = 'all' | 'none' | 'auto'
@@ -669,7 +669,7 @@ export function calculateBondsWithin (structure: Structure, onlyAddRung = false,
   const atomBondMap = onlyAddRung ? null : calculateAtomBondMap(structure)
 
   let bondedAtoms: Set<number>
-  if (!onlyAddRung && inferBonds == 'auto') {
+  if (!onlyAddRung && inferBonds === 'auto') {
     bondedAtoms = new Set()
     atomBondMap!.forEach((a, i) => {
       bondedAtoms.add(i)
@@ -687,7 +687,7 @@ export function calculateBondsWithin (structure: Structure, onlyAddRung = false,
         return
       }
 
-      if (inferBonds == 'auto') {
+      if (inferBonds === 'auto' && r.hetero) {
         // Are bonds present on this residue?
         for (let rai=r.atomOffset; rai<r.atomEnd; rai++) {
           if (bondedAtoms.has(rai)) return

--- a/src/structure/structure-utils.ts
+++ b/src/structure/structure-utils.ts
@@ -501,14 +501,22 @@ export function calculateChainnames (structure: Structure, useExistingBonds = fa
   if (Debug) Log.timeEnd('calculateChainnames')
 }
 
-export function calculateBonds (structure: Structure) {
+export function calculateBonds (structure: Structure, inferBonds: InferBondsOptions='all') {
+  if (inferBonds === 'none') return 
   if (Debug) Log.time('calculateBonds')
 
-  calculateBondsWithin(structure)
+  calculateBondsWithin(structure, false, inferBonds)
   calculateBondsBetween(structure)
 
   if (Debug) Log.timeEnd('calculateBonds')
 }
+
+/**
+ * Should Bonds be inferred for `all` atoms, `none` or `auto`
+ * If `auto`, any residue with at least one CONECT record will 
+ * not have bonding inferred, and will rely on the CONECT records
+ */
+export type InferBondsOptions = 'all' | 'none' | 'auto'
 
 export interface ResidueBonds {
   atomIndices1: number[]
@@ -649,7 +657,7 @@ export function calculateAtomBondMap (structure: Structure) {
   return atomBondMap
 }
 
-export function calculateBondsWithin (structure: Structure, onlyAddRung = false) {
+export function calculateBondsWithin (structure: Structure, onlyAddRung = false, inferBonds: InferBondsOptions='all') {
   if (Debug) Log.time('calculateBondsWithin')
 
   const bondStore = structure.bondStore
@@ -660,6 +668,15 @@ export function calculateBondsWithin (structure: Structure, onlyAddRung = false)
   const bp = structure.getBondProxy()
   const atomBondMap = onlyAddRung ? null : calculateAtomBondMap(structure)
 
+  let bondedAtoms: Set<number>
+  if (!onlyAddRung && inferBonds == 'auto') {
+    bondedAtoms = new Set()
+    atomBondMap!.forEach((a, i) => {
+      bondedAtoms.add(i)
+      a.forEach(j => {bondedAtoms.add(j)})
+    })
+  }
+
   structure.eachResidue(function (r) {
     if (!onlyAddRung && atomBondMap) {
       const count = r.atomCount
@@ -668,6 +685,13 @@ export function calculateBondsWithin (structure: Structure, onlyAddRung = false)
       if (count > 500) {
         Log.warn('more than 500 atoms, skip residue for auto-bonding', r.qualifiedName())
         return
+      }
+
+      if (inferBonds == 'auto') {
+        // Are bonds present on this residue?
+        for (let rai=r.atomOffset; rai<r.atomEnd; rai++) {
+          if (bondedAtoms.has(rai)) return
+        }
       }
 
       const bonds = r.getBonds()
@@ -732,10 +756,18 @@ export function calculateBondsBetween (structure: Structure, onlyAddBackbone = f
     if (bbType1 !== UnknownBackboneType && bbType1 === bbType2) {
       ap1.index = rp1.backboneEndAtomIndex
       ap2.index = rp2.backboneStartAtomIndex
-      if ((useExistingBonds && ap1.hasBondTo(ap2)) || ap1.connectedTo(ap2)) {
-        if (!onlyAddBackbone) {
-          bondStore.addBond(ap1, ap2, 1)  // assume single bond
-        }
+      let needsBond = false
+      let needsBackbone = false
+
+      if (useExistingBonds && ap1.hasBondTo(ap2)) {
+        needsBond = false
+        needsBackbone = true
+      } else if (ap1.connectedTo(ap2)) {
+        needsBond = !onlyAddBackbone
+        needsBackbone = true
+      }
+      if (needsBond) {bondStore.addBond(ap1, ap2, 1)}  // assume single bond
+      if (needsBackbone) {
         ap1.index = rp1.traceAtomIndex
         ap2.index = rp2.traceAtomIndex
         backboneBondStore.addBond(ap1, ap2)


### PR DESCRIPTION
For some PDB format files, I am seeing extra bonds drawn between atoms when they are within what would normally be considered covalent range but not actually bonded (I'm trying to find some good CSD examples I can share and will update with an appropriate test case). The current rules for detecting bonds use sum of some preset covalent radii and a threshold, but some of these structures legitimately fall within this threshold, though there is no bond.

This PR adds an `inferBonds` parameter when loading a structure, currently only consumed by the PDB parser class. It's behaviour is:

* `all` - Default, existing behaviour - creates bonds between any atoms within in a residue according to distance rules
* `auto` - For a het group residue (and only het groups), if any bonds are specified (by CONECT records) then only use the CONECT records, otherwise behave as before
* `none` - Don't infer any bonds at all based on distance

It also makes `structureBuilder` a declared member of `StructureParser` (it is initiated in it's constructor already) and fixes up a few minor type errors that result from having the type information.

As I said, I'll add a test but wanted to push what I had so far in case anyone has a view on doing it differently.
