### PR TITLE
Broaden undefined check when applying representation parameters.

### DIFF
--- a/src/representation/representation.ts
+++ b/src/representation/representation.ts
@@ -586,7 +586,7 @@ class Representation {
 
     for (let name in p) {
       if (p[ name ] === undefined) continue
-      if (tp[ name ] === undefined) continue
+      if (tp[ name ] == undefined ) continue // Skip nulls as well as undefined
 
       if (tp[ name ].int) p[ name ] = parseInt(p[ name ] as string)
       if (tp[ name ].float) p[ name ] = parseFloat(p[ name ] as string)


### PR DESCRIPTION
Some representation types (label) specifically set their parameters like 'linewidth' to null (e.g [here](https://github.com/nglviewer/ngl/blob/83cea2007c27222f79f9cbf9dd699866383255d1/src/representation/label-representation.ts#L220)) . If you try to setParameters({linewidth: 1.5}) this would attempt to access attributes on null in the Representation `setParameters` method [here](https://github.com/nglviewer/ngl/blob/83cea2007c27222f79f9cbf9dd699866383255d1/src/representation/representation.ts#L591). 

This one char fix avoids throwing an error (though obviously setting linewidth:1.5 on a label representation is meaningless anyway, but unhandled exceptions are bad).