### PR TITLE
Check for missing `pdbx_PDB_helix_class` in CifParser

### DIFF
--- a/src/parser/cif-parser.ts
+++ b/src/parser/cif-parser.ts
@@ -285,7 +285,7 @@ function processSecondaryStructure (cif: Cif, structure: Structure, asymIdDict: 
   // get helices
   var sc = cif.struct_conf
 
-  if (sc && sc.pdbx_PDB_helix_class) {
+  if (sc?.pdbx_PDB_helix_class) {
     ensureArray(sc, 'id')
 
     for (i = 0, il = sc.beg_auth_seq_id.length; i < il; ++i) {

--- a/src/parser/cif-parser.ts
+++ b/src/parser/cif-parser.ts
@@ -285,7 +285,7 @@ function processSecondaryStructure (cif: Cif, structure: Structure, asymIdDict: 
   // get helices
   var sc = cif.struct_conf
 
-  if (sc) {
+  if (sc && sc.pdbx_PDB_helix_class) {
     ensureArray(sc, 'id')
 
     for (i = 0, il = sc.beg_auth_seq_id.length; i < il; ++i) {


### PR DESCRIPTION
Resolves #980. AlphaFold-DB structures in .cif format seem to miss `pdbx_PDB_helix_class` values, which causes an error. The introduced check prevents this issue. Example:
https://alphafold.ebi.ac.uk/files/AF-Q5VSL9-F1-model_v4.cif

How to reproduce:

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title>Title</title>
  <script src="build/js/ngl.dev.js"></script>
</head>
<body>
<div id="viewport" style="width:400px; height:400px; "></div>

<script>

    new NGL.Stage("viewport", {backgroundColor: 'grey'}).loadFile(
        'https://alphafold.ebi.ac.uk/files/AF-Q5VSL9-F1-model_v4.cif'
    ).then(structure => {
            structure.addRepresentation("cartoon");
            structure.autoView();
        }
    ).catch(alert);

</script>
</body>
</html>
```

Before the change, this code snippet should throw an error, because `sc.pdbx_PDB_helix_class` is undefined. After the proposed change, the error is resolved.