### PR TITLE
added scroll for focusScroll in pymol mouse controls

### DIFF
--- a/src/controls/mouse-actions.ts
+++ b/src/controls/mouse-actions.ts
@@ -246,6 +246,7 @@ export const MouseActionPresets = {
     [ 'drag-left', MouseActions.rotateDrag ],
     [ 'drag-middle', MouseActions.panDrag ],
     [ 'drag-right', MouseActions.zoomDrag ],
+    [ 'scroll', MouseActions.focusScroll ],
     [ 'drag-shift-right', MouseActions.focusScroll ],
 
     [ 'clickPick-ctrl+shift-middle', MouseActions.movePick ],


### PR DESCRIPTION
Both scroll and drag-shift-right do focusScroll action in pymol, but scroll is more intuitive, because this makes controls mouse-only.