### PR TITLE
#999 cif parsing

### DIFF
--- a/src/parser/cif-parser.ts
+++ b/src/parser/cif-parser.ts
@@ -1072,7 +1072,7 @@ class CifParser extends StructureParser {
       _parseChunkOfLines(0, lines.length, lines)
     })
 
-    if (cif.chem_comp && cif.chem_comp_atom) {
+    if (cif.chem_comp && cif.chem_comp_atom && !cif.struct) {
       parseChemComp(cif, s, sb)
       sb.finalize()
       s.finalizeAtoms()


### PR DESCRIPTION
This PR fixes 2 bugs in relation with CIF files parsing:
- #999 chem_comp can be set for macromolecular cif files and contain vectors of entities. In the case of mmCIF files the block of code that parses files containing only one entity (such as PDB het cif files) must not be reached.
- #950 core cif files often define charges as part of the atom type symbol. In that case, the element symbol must be stripped of the charge.