### PR TITLE
#1010 Colormaker-constructor

### DIFF
--- a/src/color/colormaker-registry.ts
+++ b/src/color/colormaker-registry.ts
@@ -201,15 +201,13 @@ class ColormakerRegistry {
     delete this.userSchemes[ id ]
   }
 
-  _createScheme (constructor: any) {
-    const _Colormaker = function (this: any, params: ColormakerParameters) {
-      Colormaker.call(this, params)
-      constructor.call(this, params)
+  _createScheme (constructor: any): typeof Colormaker {
+    class _Colormaker extends Colormaker {
+      constructor (params: ColormakerParameters) {
+        super(params)
+        constructor.call(this, params)
+      }
     }
-
-    _Colormaker.prototype = Colormaker.prototype
-    _Colormaker.prototype.constructor = Colormaker
-
     return _Colormaker
   }
 

--- a/src/color/colormaker-registry.ts
+++ b/src/color/colormaker-registry.ts
@@ -9,6 +9,8 @@ import Colormaker, { ColormakerConstructor, ColormakerParameters } from './color
 import SelectionColormaker, { SelectionSchemeData } from './selection-colormaker'
 import Structure from '../structure/structure'
 
+type ColormakerDefinitionFunction = ((this: Colormaker, param?: ColormakerParameters) => void)
+
 const ColormakerScales = {
   '': '',
 
@@ -170,8 +172,8 @@ class ColormakerRegistry {
    * @param {String} label - scheme label
    * @return {String} id to refer to the registered scheme
    */
-  addScheme (scheme: ColormakerConstructor, label?: string) {
-    if (!(scheme instanceof Colormaker)) {
+  addScheme (scheme: ColormakerConstructor|ColormakerDefinitionFunction, label?: string) {
+    if (!(isColormakerSubClass(scheme))) {
       scheme = this._createScheme(scheme)
     }
 
@@ -202,7 +204,7 @@ class ColormakerRegistry {
     delete this.userSchemes[ id ]
   }
 
-  _createScheme (constructor: any): ColormakerConstructor {
+  _createScheme (constructor: ColormakerDefinitionFunction): ColormakerConstructor {
     class _Colormaker extends Colormaker {
       constructor (params: ColormakerParameters) {
         super(params)
@@ -254,6 +256,12 @@ class ColormakerRegistry {
     id = id.toLowerCase()
     return id in this.schemes || id in this.userSchemes
   }
+}
+
+function isColormakerSubClass (
+  scheme: ColormakerConstructor|((this: Colormaker, param?: ColormakerParameters) => void)
+): scheme is ColormakerConstructor {
+  return (scheme instanceof Colormaker)
 }
 
 export default ColormakerRegistry

--- a/src/color/colormaker.ts
+++ b/src/color/colormaker.ts
@@ -61,6 +61,7 @@ export interface ColormakerParameters extends ScaleParameters {
 export type StuctureColormakerParams = { structure: Structure } & Partial<ColormakerParameters>
 export type VolumeColormakerParams = { volume: Volume } & Partial<ColormakerParameters>
 export type ColormakerScale = (v: number) => number
+export type ColormakerConstructor = new (...p: ConstructorParameters<typeof Colormaker>) => Colormaker
 
 const tmpColor = new Color()
 


### PR DESCRIPTION
This PR fixes issue #1010 where the syntax for registering a ColorMaker does not generate valid JS.

After bissection, I've found out that this issue has been introduced with the recent changes to the build process (PR #993). It's possible that the transpilation + bundling results in invalid JS code (?).
The fix was already done in the update-three,js ongoing branch, and had been cherry-picked from there.