### PR TITLE
Rcsb provider fixes

### DIFF
--- a/src/datasource/pdbe-datasource.ts
+++ b/src/datasource/pdbe-datasource.ts
@@ -49,7 +49,7 @@ class PDBeDatasource extends Datasource {
 
   getExt (src: string) {
     const ext = getFileInfo(src).ext
-    return ext ? ext : 'mmtf'
+    return ext ? ext : 'bcif'
   }
 }
 

--- a/src/datasource/rcsb-datasource.ts
+++ b/src/datasource/rcsb-datasource.ts
@@ -5,15 +5,12 @@
  */
 
 import { Log, DatasourceRegistry } from '../globals'
-import { getProtocol } from '../utils'
 import { getFileInfo } from '../loader/loader-utils'
 import Datasource from './datasource'
 
 const baseUrl = '//files.rcsb.org/download/'
-const mmtfBaseUrl = '//mmtf.rcsb.org/v1.0/'
-const mmtfFullUrl = mmtfBaseUrl + 'full/'
-const mmtfReducedUrl = mmtfBaseUrl + 'reduced/'
 const bcifBaseUrl = '//models.rcsb.org/'
+const protocol = 'https:'
 
 class RcsbDatasource extends Datasource {
   getUrl (src: string) {
@@ -22,35 +19,32 @@ class RcsbDatasource extends Datasource {
     // XXXX defaults to XXXX.cif
     const info = getFileInfo(src)
     const pdbid = info.name.indexOf('_') > -1 ? info.name : info.name.substring(0, 4) // Allow extended pdb codes and alphafold codes
-    let url
     if ([ 'pdb', 'cif' ].includes(info.ext) &&
         (info.compressed === false || info.compressed === 'gz')
     ) {
-      url = baseUrl + info.path
-    } else if (info.ext === 'mmtf') {
-      Log.warn('MMTF files distribution is discontinued by RCSB PDB as of July 2, 2024.\n Consider using bcif format instead. See https://www.rcsb.org/news/65a1af31c76ca3abcc925d0c for the deprecation notice')
+      return protocol + baseUrl + info.path
+    }
+
+    if (info.ext === 'mmtf') {
+      Log.warn('MMTF files distribution has been discontinued by RCSB PDB as of July 2024.\n Defaulting to bcif format instead. See https://www.rcsb.org/news/65a1af31c76ca3abcc925d0c for the deprecation notice')
       if (info.base.endsWith('.bb')) {
-        url = mmtfReducedUrl + pdbid
-      } else {
-        url = mmtfFullUrl + pdbid
+        Log.warn('Backbone only files are not available from RCSB PDB anymore.')
       }
-    } else if (info.ext === 'bcif' &&
-        (info.compressed === false || info.compressed === 'gz')
-    ) {
-      url = bcifBaseUrl + info.path
-    } else if (!info.ext) {
+      info.ext = ''
+    }
+
+    if (!info.ext) {
       Log.warn('mmCif files available from RCSB PDB lack connectivity information.\n Consider using PDBe as the data provider for using "Updated mmCif files" that contain residues connectivity records.')
-      url = bcifBaseUrl + pdbid + '.bcif.gz'
     } else {
       Log.warn('unsupported ext', info.ext)
-      url = bcifBaseUrl + pdbid + '.bcif.gz'
     }
-    return getProtocol() + url
+
+    return protocol + bcifBaseUrl + pdbid + '.bcif.gz'
   }
 
   getExt (src: string) {
     const ext = getFileInfo(src).ext
-    return ext ? ext : 'mmtf'
+    return ext ? ext : 'bcif'
   }
 }
 


### PR DESCRIPTION
This PR fixes 2 issues:
- mmtf format is not supported by data providers (RCSB and PDBe)
- RCSB redirects from http to https but this can't be followed by the request code. Calls are now only made to https